### PR TITLE
fix numpy version to 1.17.5, which is the latest version that is comp…

### DIFF
--- a/container-optimized/Dockerfile
+++ b/container-optimized/Dockerfile
@@ -29,6 +29,7 @@ RUN rm -rf /root/.ssh/ && \
   cp /root/.ssh/id_rsa.pub /root/.ssh/authorized_keys && \
   printf "Host *\n  StrictHostKeyChecking no\n" >> /root/.ssh/config
 
+RUN pip install numpy==1.17.5
 RUN pip install awscli
 RUN pip install boto3
 RUN pip install ujson==1.35
@@ -43,4 +44,4 @@ RUN cd /mask-rcnn-tensorflow && git fetch origin 153442bc70b06e59f2bbeadc4d359b2
 RUN cd /mask-rcnn-tensorflow && git reset --hard 153442bc70b06e59f2bbeadc4d359b240f64cbc2
 
 RUN chmod -R +w /mask-rcnn-tensorflow
-RUN pip install --ignore-installed -e /mask-rcnn-tensorflow/
+RUN pip install -e /mask-rcnn-tensorflow/

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -2,6 +2,7 @@ FROM  763104351884.dkr.ecr.us-west-2.amazonaws.com/tensorflow-training:1.13-horo
 
 RUN pip install --upgrade pip
 
+RUN pip install numpy==1.17.5
 RUN pip install awscli
 RUN pip install boto3
 RUN pip install ujson==1.35
@@ -14,4 +15,4 @@ RUN pip install markdown==3.1
 RUN git clone https://github.com/tensorpack/tensorpack.git /tensorpack
 RUN cd /tensorpack && git fetch origin 26664c3f1d58ae029ea6c3ba0af6ae11900b1e55 
 RUN cd /tensorpack && git reset --hard 26664c3f1d58ae029ea6c3ba0af6ae11900b1e55 
-RUN pip install --ignore-installed -e /tensorpack
+RUN pip install -e /tensorpack


### PR DESCRIPTION
…atible with the fixed version of pycocotools.

*Issue #, if available:*

#4 

*Description of changes:*

Fix numpy version to 1.17.5, which is the latest version compatible with the version of pycocotools that is used. Also remove `--ignore-installed` from the tensorpack/MRCNN installation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
