### PR TITLE
Add an example for serving Qwen3-0.6B model on Triton Server, with low resource requirements.

### DIFF
--- a/examples/inference/triton-inference-server/vllm_backend/qwen3-0.6b/README.md
+++ b/examples/inference/triton-inference-server/vllm_backend/qwen3-0.6b/README.md
@@ -1,0 +1,44 @@
+# Serve Qwen/Qwen3-0.6B using Triton Inference Server
+
+This example shows how to serve [Qwen3-0.6B](https://huggingface.co/Qwen/Qwen3-0.6B) model using [Triton Inference Server](https://github.com/triton-inference-server) with [vLLM backend](https://github.com/triton-inference-server/vllm_backend/tree/main). 
+
+## Prerequisites
+
+Before proceeding, complete the [Prerequisites](../../../../../README.md#prerequisites) and [Launch desktop](../../../../../README.md##launch-build-machine-desktop).
+
+See [What is in the YAML file](../../../../../README.md#yaml-recipes) to understand the common fields in the Helm values files. There are some fields that are specific to a machine learning chart.
+
+## Download Hugging Face Qwen3-0.6B pre-trained model weights
+
+To download Hugging Face Qwen3-0.6B  pre-trained model weights, replace `YourHuggingFaceToken` with your Hugging Face token below, and execute:
+
+    cd ~/amazon-eks-machine-learning-with-terraform-and-kubeflow
+    helm install --debug triton-server-qwen3-0-6b-vllm    \
+        charts/machine-learning/model-prep/hf-snapshot    \
+        --set-json='env=[{"name":"HF_MODEL_ID","value":"Qwen/Qwen3-0.6B"},{"name":"HF_TOKEN","value":"YourHuggingFaceToken"}]' \
+        -n kubeflow-user-example-com
+
+Uninstall the Helm chart at completion:
+
+    helm uninstall triton-server-qwen3-0-6b-vllm -n kubeflow-user-example-com
+
+## Launch Triton Server
+
+To launch Triton server:
+
+    cd ~/amazon-eks-machine-learning-with-terraform-and-kubeflow
+    helm install --debug triton-server-qwen3-0-6b-vllm \
+        charts/machine-learning/serving/triton-inference-server \
+        -f examples/inference/triton-inference-server/vllm_backend/qwen3-0.6b/triton_server.yaml -n kubeflow-user-example-com
+
+
+## Stop Service
+
+To stop the service:
+
+    cd ~/amazon-eks-machine-learning-with-terraform-and-kubeflow
+    helm uninstall triton-server-qwen3-0-6b-vllm -n kubeflow-user-example-com
+
+## Logs
+
+Triton server logs are available in `/efs/home/triton-server-qwen3-0-6b-vllm/logs` folder.

--- a/examples/inference/triton-inference-server/vllm_backend/qwen3-0.6b/triton_server.yaml
+++ b/examples/inference/triton-inference-server/vllm_backend/qwen3-0.6b/triton_server.yaml
@@ -1,0 +1,99 @@
+image: 
+  name: nvcr.io/nvidia/tritonserver:25.07-vllm-python-py3
+resources:
+  node_type: g6.xlarge
+  requests:
+    "nvidia.com/gpu": 1
+  limits:
+    "nvidia.com/gpu": 1
+tolerations:
+  - key: "nvidia.com/gpu"
+    operator: "Exists"
+    effect: "NoSchedule"
+ebs:
+  storage: 400Gi
+  mount_path: /tmp
+inline_script:
+- |+
+  cat > /tmp/config.pbtxt <<EOF
+  backend: "vllm"
+
+  instance_group [
+    {
+      count: 1
+      kind: KIND_MODEL
+    }
+  ]
+  
+  EOF
+- |+
+  cat > /tmp/model.json <<EOF
+  {
+    "model": "$MODEL_PATH",
+    "tokenizer": "$MODEL_PATH",
+    "tokenizer_mode": "auto",
+    "disable_log_requests": "true",
+    "gpu_memory_utilization": 0.8,
+    "dtype": "auto",
+    "tensor_parallel_size": 1,
+    "pipeline_parallel_size": 1,
+    "max_num_seqs": 8
+  }
+
+  EOF
+
+pre_script: 
+  - mkdir -p $LOG_ROOT
+  - OUTPUT_LOG="$LOG_ROOT/triton_server.log"
+  - rm -rf $MODEL_REPO
+  - mkdir -p $MODEL_REPO
+  - VERSION=1
+  - MODEL_NAME=qwen3-0.6b
+  - mkdir -p $MODEL_REPO/$MODEL_NAME/$VERSION
+  - cp /tmp/model.json $MODEL_REPO/$MODEL_NAME/$VERSION/model.json
+  - cp /tmp/config.pbtxt $MODEL_REPO/$MODEL_NAME/config.pbtxt
+server:
+  ports:
+    - name: 'http'
+      value: '8000'
+    - name: 'grpc'
+      value: '8001'
+    - name: 'metric'
+      value: '8002'
+  readiness_probe:
+    period_secs: 5
+    failure_threshold: 3
+  startup_probe:
+    period_secs: 10
+    failure_threshold: 30
+  liveness_probe:
+    period_secs: 10
+    failure_threshold: 3
+  env:
+    - name: HOME
+      value: /tmp
+    - name: LOG_ROOT
+      value: /efs/home/{{ .Release.Name }}/logs
+    - name: MODEL_REPO
+      value: /efs/home/{{ .Release.Name }}/model_repository
+    - name: MODEL_PATH
+      value: "/fsx/pretrained-models/Qwen/Qwen3-0.6B"
+  command:
+    - tritonserver
+  args:
+    - --model-repository=${MODEL_REPO}
+    - --grpc-port=8001
+    - --http-port=8000
+    - --metrics-port=8002
+    - --log-file=$OUTPUT_LOG
+  autoscaling:
+    minReplicas: 1
+    maxReplicas: 4
+    metrics:
+      - type: Pods
+        pods:
+          metric:
+            name: avg_time_queue_us
+          target:
+            type: AverageValue
+            averageValue: 50


### PR DESCRIPTION
### This PR
1.  Add triton server example for Qwen3-0.6B model
    - Use latest triton docker image 25.07
    - Use one g6.xlarge instance as resource 
3. Add README

### Test
Deployed this stack to AWS g6.xlarge instance, server is up and running as expected:
```
root@triton-server-qwen3-0-6b-vllm-76865cdd-s7c5p:/opt/tritonserver# curl -X POST localhost:8000/v2/models/qwen3-0.6b/generate -d '{"text_input": "What is Triton Inference Server?", "parameters": {"stream": false, "temperature": 0, "max_tokens": 128}}’

# output
{ 
   "model_name":"qwen3-0.6b",
   "model_version":"1",
   "text_output":"What is Triton Inference Server? What is its purpose and use case?\n\nTriton Inference Server is a powerful tool that allows developers to deploy and manage their machine learning models on a cloud platform. It provides a user-friendly interface for training, testing, and deploying models, making it easier for developers to work with their models without needing to have a deep understanding of the underlying infrastructure.\n\nThe Triton Inference Server is designed to be a lightweight and efficient solution for deploying machine learning models. It supports various types of models, including those that are trained on different data sources and can be used in different applications. The server is also capable of handling multiple models and can be"
}
```