### PR TITLE
Fix setup instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,12 @@ cp terraform.tfvars.example terraform.tfvars # Add/modify variables as needed
 ### 6. Create Home Folders on Shared Storage
 
 ```bash
+cd ~/amazon-eks-machine-learning-with-terraform-and-kubeflow/
 kubectl apply -f eks-cluster/utils/attach-pvc.yaml -n kubeflow
+# wait for the `attach-pvc` Pod to be in "ready" Status. 
+# check status of the Pod by running
+kubectl get pods -n kubeflow -w
+# Once the attach-pvc Pod is Ready, run the following commands
 kubectl exec -it -n kubeflow attach-pvc -- /bin/bash
 
 # Inside pod


### PR DESCRIPTION
*Issue #, if available:*
Mismatch in README with actual Cloud Desktop log output
*Description of changes:*
Update README to match the setup instructions for ML Ops desktop

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
