### PR TITLE
Add Karpenter ODCR support

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ cp terraform.tfvars.example terraform.tfvars # Add/modify variables as needed
 
 #### Using On-Demand Capacity Reservations (ODCR)
 
-To use [ODCR](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-capacity-reservations.html) with Karpenter for guaranteed GPU/Neuron capacity, first create capacity reservations in the AWS Console or CLI, then add the ODCR variables:
+To use [ODCR](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-capacity-reservations.html) with Karpenter for guaranteed capacity on cudaefa NodePool (p4d, p5 instances), first create capacity reservations in the AWS Console or CLI, then add the ODCR variables:
 
 ```bash
 terraform apply -var="profile=default" -var="region=us-west-2" \
@@ -121,13 +121,13 @@ terraform apply -var="profile=default" -var="region=us-west-2" \
   -var="cuda_efa_az=us-west-2c" \
   -var="neuron_az=us-west-2d" \
   -var="karpenter_odcr_enabled=true" \
-  -var='karpenter_capacity_types=["reserved","on-demand"]' \
-  -var='karpenter_odcr_cuda_ids=["cr-xxxxx","cr-yyyyy"]'
+  -var='karpenter_odcr_capacity_types=["reserved","on-demand"]' \
+  -var='karpenter_odcr_cudaefa_ids=["cr-xxxxx","cr-yyyyy"]'
 ```
 
 Verify nodes launch with reserved capacity:
 ```bash
-kubectl get nodes -l karpenter.sh/nodepool=cuda -o jsonpath='{range .items[*]}{.metadata.name}: {.metadata.labels.karpenter\.sh/capacity-type}{"\n"}{end}'
+kubectl get nodes -l karpenter.sh/nodepool=cudaefa -o jsonpath='{range .items[*]}{.metadata.name}: {.metadata.labels.karpenter\.sh/capacity-type}{"\n"}{end}'
 ```
 
 ### 6. Create Home Folders on Shared Storage
@@ -320,7 +320,7 @@ Enable optional components via Terraform variables:
 | Component | Variable | Default |
 |-----------|----------|---------|
 | [Airflow](https://airflow.apache.org/) | airflow_enabled | false |
-| [Karpenter ODCR](https://karpenter.sh/docs/concepts/nodeclasses/#speccapacityreservationselectorterms) | karpenter_odcr_enabled | false |
+| [Karpenter ODCR](https://karpenter.sh/docs/concepts/nodeclasses/#speccapacityreservationselectorterms) (cudaefa only) | karpenter_odcr_enabled | false |
 | [Kubeflow](https://www.kubeflow.org/) | kubeflow_platform_enabled | false |
 | [KServe](https://kserve.github.io/website/latest/) | kserve_enabled | false |
 | [Kueue](https://kueue.sigs.k8s.io/) | kueue_enabled | false |

--- a/charts/karpenter-components/templates/node-class.yaml
+++ b/charts/karpenter-components/templates/node-class.yaml
@@ -13,19 +13,6 @@ spec:
     - tags:
         "kubernetes.io/cluster/{{ .Values.cluster_id }}": "owned"
 
-  {{- if and .Values.odcr.enabled (or (gt (len .Values.odcr.cuda.ids) 0) (gt (len .Values.odcr.cuda.tags) 0)) }}
-  capacityReservationSelectorTerms:
-    {{- range .Values.odcr.cuda.ids }}
-    - id: {{ . }}
-    {{- end }}
-    {{- if gt (len .Values.odcr.cuda.tags) 0 }}
-    - tags:
-        {{- range $key, $value := .Values.odcr.cuda.tags }}
-        {{ $key }}: {{ $value | quote }}
-        {{- end }}
-    {{- end }}
-  {{- end }}
-
   amiSelectorTerms:
     - alias: al2023@v20251103
 
@@ -93,19 +80,6 @@ spec:
   securityGroupSelectorTerms:
     - tags:
         "kubernetes.io/cluster/{{ .Values.cluster_id }}": "owned"
-
-  {{- if and .Values.odcr.enabled (or (gt (len .Values.odcr.neuron.ids) 0) (gt (len .Values.odcr.neuron.tags) 0)) }}
-  capacityReservationSelectorTerms:
-    {{- range .Values.odcr.neuron.ids }}
-    - id: {{ . }}
-    {{- end }}
-    {{- if gt (len .Values.odcr.neuron.tags) 0 }}
-    - tags:
-        {{- range $key, $value := .Values.odcr.neuron.tags }}
-        {{ $key }}: {{ $value | quote }}
-        {{- end }}
-    {{- end }}
-  {{- end }}
 
   amiSelectorTerms:
     - alias: al2023@v20251103

--- a/charts/karpenter-components/templates/node-pool.yaml
+++ b/charts/karpenter-components/templates/node-pool.yaml
@@ -24,13 +24,7 @@ spec:
       - key: karpenter.sh/capacity-type
         operator: In
         values:
-          {{- if .Values.capacity_types }}
-          {{- range .Values.capacity_types }}
-          - {{ . | quote }}
-          {{- end }}
-          {{- else }}
           - {{ .Values.capacity_type | quote }}
-          {{- end }}
       - key: node.kubernetes.io/instance-type
         operator: In
         values:
@@ -85,13 +79,7 @@ spec:
       - key: karpenter.sh/capacity-type
         operator: In
         values:
-          {{- if .Values.capacity_types }}
-          {{- range .Values.capacity_types }}
-          - {{ . | quote }}
-          {{- end }}
-          {{- else }}
           - {{ .Values.capacity_type | quote }}
-          {{- end }}
       - key: node.kubernetes.io/instance-type
         operator: In
         values:
@@ -166,8 +154,8 @@ spec:
       - key: karpenter.sh/capacity-type
         operator: In
         values:
-          {{- if .Values.capacity_types }}
-          {{- range .Values.capacity_types }}
+          {{- if and .Values.odcr.enabled .Values.odcr.cudaefa.capacity_types }}
+          {{- range .Values.odcr.cudaefa.capacity_types }}
           - {{ . | quote }}
           {{- end }}
           {{- else }}

--- a/charts/karpenter-components/values.yaml
+++ b/charts/karpenter-components/values.yaml
@@ -3,19 +3,13 @@ role_name:
 cluster_id:
 consolidate_after: "600s"
 capacity_type: "on-demand"
-capacity_types:
-  - "on-demand"
 max_pods: 20
 
-# ODCR Configuration
+# ODCR Configuration (cudaefa only)
 odcr:
   enabled: false
-  neuron:
-    ids: []
-    tags: {}
-  cuda:
-    ids: []
-    tags: {}
   cudaefa:
+    capacity_types:
+      - "on-demand"
     ids: []
     tags: {}

--- a/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/main.tf
+++ b/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/main.tf
@@ -1145,17 +1145,11 @@ resource "helm_release" "karpenter_components" {
       cluster_id: "${aws_eks_cluster.eks_cluster.id}"
       consolidate_after: "${var.karpenter_consolidate_after}"
       capacity_type: "${var.karpenter_capacity_type}"
-      capacity_types: ${jsonencode(var.karpenter_capacity_types)}
       max_pods: "${var.karpenter_max_pods}"
       odcr:
         enabled: ${var.karpenter_odcr_enabled}
-        neuron:
-          ids: ${jsonencode(var.karpenter_odcr_neuron_ids)}
-          tags: ${jsonencode(var.karpenter_odcr_neuron_tags)}
-        cuda:
-          ids: ${jsonencode(var.karpenter_odcr_cuda_ids)}
-          tags: ${jsonencode(var.karpenter_odcr_cuda_tags)}
         cudaefa:
+          capacity_types: ${jsonencode(var.karpenter_odcr_capacity_types)}
           ids: ${jsonencode(var.karpenter_odcr_cudaefa_ids)}
           tags: ${jsonencode(var.karpenter_odcr_cudaefa_tags)}
     EOT

--- a/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/variables.tf
+++ b/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/variables.tf
@@ -516,35 +516,11 @@ variable nvidia_capacity_reservation_id {
   default = ""
 }
 
-# Karpenter ODCR Configuration
+# Karpenter ODCR Configuration (cudaefa NodePool only)
 variable "karpenter_odcr_enabled" {
-  description = "Enable ODCR support for Karpenter"
+  description = "Enable ODCR support for Karpenter cudaefa NodePool"
   type        = bool
   default     = false
-}
-
-variable "karpenter_odcr_neuron_ids" {
-  description = "List of ODCR IDs for Neuron instances (e.g., ['cr-xxx', 'cr-yyy'])"
-  type        = list(string)
-  default     = []
-}
-
-variable "karpenter_odcr_neuron_tags" {
-  description = "Tags to select ODCRs for Neuron instances (e.g., {purpose = 'ml-training'})"
-  type        = map(string)
-  default     = {}
-}
-
-variable "karpenter_odcr_cuda_ids" {
-  description = "List of ODCR IDs for CUDA instances (e.g., ['cr-xxx', 'cr-yyy'])"
-  type        = list(string)
-  default     = []
-}
-
-variable "karpenter_odcr_cuda_tags" {
-  description = "Tags to select ODCRs for CUDA instances (e.g., {purpose = 'ml-inference'})"
-  type        = map(string)
-  default     = {}
 }
 
 variable "karpenter_odcr_cudaefa_ids" {
@@ -559,8 +535,8 @@ variable "karpenter_odcr_cudaefa_tags" {
   default     = {}
 }
 
-variable "karpenter_capacity_types" {
-  description = "Karpenter capacity types list: 'on-demand', 'spot', 'reserved'"
+variable "karpenter_odcr_capacity_types" {
+  description = "Karpenter ODCR capacity types list: 'on-demand', 'spot', 'reserved'"
   type        = list(string)
   default     = ["on-demand"]
 }


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
Adds support for On-Demand Capacity Reservations (ODCR) with Karpenter to guarantee GPU/Neuron instance capacity

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
