### PR TITLE
fix: update kubeflow pipelines images to working versions

### DIFF
--- a/charts/ml-platform/kubeflow-pipelines/templates/deployments.yaml
+++ b/charts/ml-platform/kubeflow-pipelines/templates/deployments.yaml
@@ -355,7 +355,7 @@ spec:
             secretKeyRef:
               key: secretkey
               name: mlpipeline-minio-artifact
-        image: gcr.io/ml-pipeline/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance
+        image: minio/minio:RELEASE.2022-12-12T19-27-27Z
         name: minio
         ports:
         - containerPort: 9000
@@ -684,7 +684,7 @@ spec:
               name: mlpipeline-minio-artifact
         - name: ALLOW_CUSTOM_VISUALIZATIONS
           value: 'true'
-        image: gcr.io/ml-pipeline/frontend:2.0.1
+        image: ghcr.io/kubeflow/kfp-frontend:2.14.3
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:


### PR DESCRIPTION
*Issue #, if available:*
kubeflow-pipeline gcr images are no longer available.
*Description of changes:*

update kubeflow pipelines images to working versions

   - minio: gcr.io/ml-pipeline/minio -> minio/minio:RELEASE.2022-12-12T19-27-27Z
   - frontend: gcr.io/ml-pipeline/frontend -> ghcr.io/kubeflow/kfp-frontend:2.14.3

   The old gcr.io/ml-pipeline images are no longer available.
   See: https://github.com/kubeflow/pipelines/issues/11600

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
