### PR TITLE
Add kmcp (Kubernetes MCP Server Controller) as optional module

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,7 @@ Enable optional components via Terraform variables:
 |-----------|----------|---------|
 | [Airflow](https://airflow.apache.org/) | airflow_enabled | false |
 | [kagent](https://github.com/kagent-dev/kagent) | kagent_enabled | false |
+| [kmcp](https://github.com/kagent-dev/kmcp) | kmcp_enabled | false |
 | [Capacity Reservations](https://karpenter.sh/docs/tasks/odcrs/) (ODCR / Capacity Blocks, cudaefa only) | karpenter_cr_enabled | false |
 | [Kubeflow](https://www.kubeflow.org/) | kubeflow_platform_enabled | false |
 | [KServe](https://kserve.github.io/website/latest/) | kserve_enabled | false |
@@ -517,6 +518,76 @@ terraform apply \
   -var="kagent_database_type=postgresql" \
   -var="kagent_controller_replicas=3"
 ```
+
+### kmcp - Kubernetes MCP Server Controller
+
+[kmcp](https://github.com/kagent-dev/kmcp) is a Kubernetes-native controller for deploying and managing [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) servers as Kubernetes resources.
+
+**Enable kmcp:**
+```bash
+terraform apply \
+  -var="kmcp_enabled=true"
+```
+
+**Configuration options:**
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `kmcp_version` | Helm chart version | `"1.0.0"` |
+| `kmcp_namespace` | Kubernetes namespace | `"kmcp-system"` |
+| `kmcp_controller_replicas` | Number of controller replicas | `1` |
+| `kmcp_enable_istio_injection` | Enable Istio sidecar injection | `false` |
+
+**Helm Charts (OCI):**
+
+kmcp is installed from two OCI Helm charts:
+- **CRDs:** `oci://ghcr.io/kagent-dev/kmcp/helm/kmcp-crds`
+- **Controller:** `oci://ghcr.io/kagent-dev/kmcp/helm/kmcp`
+
+CRDs are installed by a separate Helm release and must be upgraded first when updating versions. To pin a specific version, set `kmcp_version`. To override the controller image (e.g., for private registries), use `additional_helm_values`:
+
+```hcl
+# In your tfvars or -var flags:
+kmcp_version = "1.0.0"
+
+# Override image registry/tag via additional_helm_values:
+# kmcp_additional_helm_values = <<-EOT
+#   controller:
+#     image:
+#       registry: my-registry.example.com
+#       repository: kmcp/controller
+#       tag: "1.0.0-custom"
+# EOT
+```
+
+**Access controller metrics:**
+```bash
+kubectl port-forward -n kmcp-system svc/kmcp-controller-metrics 8443:8443
+# or use the Terraform output:
+$(terraform output -raw kmcp_metrics_access_command)
+```
+
+**Istio sidecar injection:**
+
+When `kmcp_enable_istio_injection=true`, the namespace is labeled with `istio-injection=enabled`. If the controller readiness probe fails after enabling Istio, ensure `holdApplicationUntilProxyStarts` is set in your Istio mesh config, or add a `postStart` hook to wait for the sidecar.
+
+**Example: Deploy an MCP server**
+
+Once kmcp is installed, create `MCPServer` custom resources to deploy MCP servers:
+
+```yaml
+apiVersion: kagent.dev/v1alpha1
+kind: MCPServer
+metadata:
+  name: my-mcp-server
+  namespace: kmcp-system
+spec:
+  transport: sse
+  image: my-mcp-server-image:latest
+  port: 8080
+```
+
+For full documentation, see the [kmcp repository](https://github.com/kagent-dev/kmcp).
 
 ## Legacy Examples
 

--- a/README.md
+++ b/README.md
@@ -533,7 +533,7 @@ terraform apply \
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `kmcp_version` | Helm chart version | `"1.0.0"` |
+| `kmcp_version` | Helm chart version | `"0.1.4"` |
 | `kmcp_namespace` | Kubernetes namespace | `"kmcp-system"` |
 | `kmcp_controller_replicas` | Number of controller replicas | `1` |
 | `kmcp_enable_istio_injection` | Enable Istio sidecar injection | `false` |
@@ -548,7 +548,7 @@ CRDs are installed by a separate Helm release and must be upgraded first when up
 
 ```hcl
 # In your tfvars or -var flags:
-kmcp_version = "1.0.0"
+kmcp_version = "0.1.4"
 
 # Override image registry/tag via additional_helm_values:
 # kmcp_additional_helm_values = <<-EOT

--- a/README.md
+++ b/README.md
@@ -567,6 +567,8 @@ kubectl port-forward -n kmcp-system svc/kmcp-controller-metrics 8443:8443
 $(terraform output -raw kmcp_metrics_access_command)
 ```
 
+**Prometheus ServiceMonitor:** Set `enable_service_monitor=true` in the module to create a ServiceMonitor for automatic Prometheus scraping. When `metrics_secure_serving` is enabled, the ServiceMonitor automatically uses `scheme: https` with `insecureSkipVerify: true`. For production, replace `insecureSkipVerify` with proper CA configuration via `additional_helm_values`.
+
 **Istio sidecar injection:**
 
 When `kmcp_enable_istio_injection=true`, the namespace is labeled with `istio-injection=enabled`. If the controller readiness probe fails after enabling Istio, ensure `holdApplicationUntilProxyStarts` is set in your Istio mesh config, or add a `postStart` hook to wait for the sidecar.

--- a/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/kmcp.tf
+++ b/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/kmcp.tf
@@ -10,8 +10,6 @@ module "kmcp" {
   # Basic configuration
   kmcp_namespace = var.kmcp_namespace
   kmcp_version   = var.kmcp_version
-  cluster_name   = var.cluster_name
-  region         = var.region
 
   # Controller configuration
   controller_replicas = var.kmcp_controller_replicas

--- a/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/kmcp.tf
+++ b/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/kmcp.tf
@@ -1,0 +1,25 @@
+#---------------------------------------------------------------
+# kmcp - Kubernetes MCP Server Controller
+# https://github.com/kagent-dev/kmcp
+#---------------------------------------------------------------
+
+module "kmcp" {
+  count  = var.kmcp_enabled ? 1 : 0
+  source = "./kmcp"
+
+  # Basic configuration
+  kmcp_namespace = var.kmcp_namespace
+  kmcp_version   = var.kmcp_version
+  cluster_name   = var.cluster_name
+  region         = var.region
+
+  # Controller configuration
+  controller_replicas = var.kmcp_controller_replicas
+
+  # Istio sidecar injection
+  enable_istio_injection = var.kmcp_enable_istio_injection
+
+  depends_on = [
+    module.eks_blueprints_addons
+  ]
+}

--- a/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/kmcp/main.tf
+++ b/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/kmcp/main.tf
@@ -131,11 +131,19 @@ resource "kubernetes_manifest" "kmcp_service_monitor" {
         }
       }
       endpoints = [
-        {
-          port     = "metrics"
-          interval = "30s"
-          path     = "/metrics"
-        }
+        merge(
+          {
+            port     = "metrics"
+            interval = "30s"
+            path     = "/metrics"
+          },
+          var.metrics_secure_serving ? {
+            scheme = "https"
+            tlsConfig = {
+              insecureSkipVerify = true
+            }
+          } : {}
+        )
       ]
     }
   }

--- a/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/kmcp/main.tf
+++ b/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/kmcp/main.tf
@@ -145,7 +145,10 @@ resource "kubernetes_manifest" "kmcp_service_monitor" {
             tlsConfig = {
               insecureSkipVerify = true
             }
-          } : {}
+          } : {
+            scheme    = null
+            tlsConfig = null
+          }
         )
       ]
     }

--- a/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/kmcp/main.tf
+++ b/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/kmcp/main.tf
@@ -8,10 +8,10 @@
 resource "kubernetes_namespace" "kmcp" {
   metadata {
     name = var.kmcp_namespace
-    labels = {
-      name            = var.kmcp_namespace
-      istio-injection = var.enable_istio_injection ? "enabled" : "disabled"
-    }
+    labels = merge(
+      { name = var.kmcp_namespace },
+      var.enable_istio_injection ? { "istio-injection" = "enabled" } : {}
+    )
   }
 }
 

--- a/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/kmcp/main.tf
+++ b/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/kmcp/main.tf
@@ -1,0 +1,146 @@
+# kmcp - Kubernetes MCP Server Controller
+# https://github.com/kagent-dev/kmcp
+
+#---------------------------------------------------------------
+# Namespace
+#---------------------------------------------------------------
+
+resource "kubernetes_namespace" "kmcp" {
+  metadata {
+    name = var.kmcp_namespace
+    labels = {
+      name            = var.kmcp_namespace
+      istio-injection = var.enable_istio_injection ? "enabled" : "disabled"
+    }
+  }
+}
+
+#---------------------------------------------------------------
+# kmcp CRDs Helm Release (install first)
+#---------------------------------------------------------------
+
+resource "helm_release" "kmcp_crds" {
+  name       = "kmcp-crds"
+  chart      = "kmcp-crds"
+  repository = "oci://ghcr.io/kagent-dev/kmcp/helm"
+  version    = var.kmcp_version
+  namespace  = kubernetes_namespace.kmcp.metadata[0].name
+
+  skip_crds = false
+  wait      = true
+
+  depends_on = [
+    kubernetes_namespace.kmcp
+  ]
+}
+
+#---------------------------------------------------------------
+# kmcp Main Helm Release
+#---------------------------------------------------------------
+
+resource "helm_release" "kmcp" {
+  name       = "kmcp"
+  chart      = "kmcp"
+  repository = "oci://ghcr.io/kagent-dev/kmcp/helm"
+  version    = var.kmcp_version
+  namespace  = kubernetes_namespace.kmcp.metadata[0].name
+
+  # Controller replicas
+  set {
+    name  = "controller.replicas"
+    value = var.controller_replicas
+  }
+
+  # Resource requests
+  set {
+    name  = "controller.resources.requests.cpu"
+    value = var.controller_cpu_request
+  }
+
+  set {
+    name  = "controller.resources.requests.memory"
+    value = var.controller_memory_request
+  }
+
+  # Resource limits
+  set {
+    name  = "controller.resources.limits.cpu"
+    value = var.controller_cpu_limit
+  }
+
+  set {
+    name  = "controller.resources.limits.memory"
+    value = var.controller_memory_limit
+  }
+
+  # Leader election
+  set {
+    name  = "controller.leaderElection.enabled"
+    value = var.enable_leader_election
+  }
+
+  # Metrics
+  set {
+    name  = "controller.metrics.enabled"
+    value = var.enable_metrics
+  }
+
+  dynamic "set" {
+    for_each = var.enable_metrics ? [1] : []
+    content {
+      name  = "controller.metrics.secure"
+      value = var.metrics_secure_serving
+    }
+  }
+
+  # Health probes
+  set {
+    name  = "controller.health.enabled"
+    value = "true"
+  }
+
+  # Additional Helm values
+  values = var.additional_helm_values != "" ? [var.additional_helm_values] : []
+
+  depends_on = [
+    helm_release.kmcp_crds
+  ]
+}
+
+#---------------------------------------------------------------
+# Prometheus ServiceMonitor (optional)
+#---------------------------------------------------------------
+
+resource "kubernetes_manifest" "kmcp_service_monitor" {
+  count = var.enable_service_monitor ? 1 : 0
+
+  manifest = {
+    apiVersion = "monitoring.coreos.com/v1"
+    kind       = "ServiceMonitor"
+    metadata = {
+      name      = "kmcp-controller-metrics"
+      namespace = kubernetes_namespace.kmcp.metadata[0].name
+      labels = {
+        app = "kmcp"
+      }
+    }
+    spec = {
+      selector = {
+        matchLabels = {
+          "app.kubernetes.io/name" = "kmcp"
+        }
+      }
+      endpoints = [
+        {
+          port     = "metrics"
+          interval = "30s"
+          path     = "/metrics"
+        }
+      ]
+    }
+  }
+
+  depends_on = [
+    helm_release.kmcp
+  ]
+}

--- a/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/kmcp/main.tf
+++ b/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/kmcp/main.tf
@@ -51,7 +51,7 @@ resource "helm_release" "kmcp" {
   # Controller replicas
   set {
     name  = "controller.replicas"
-    value = var.controller_replicas
+    value = tostring(var.controller_replicas)
   }
 
   # Resource requests
@@ -79,20 +79,20 @@ resource "helm_release" "kmcp" {
   # Leader election
   set {
     name  = "controller.leaderElection.enabled"
-    value = var.enable_leader_election
+    value = tostring(var.enable_leader_election)
   }
 
   # Metrics
   set {
     name  = "controller.metrics.enabled"
-    value = var.enable_metrics
+    value = tostring(var.enable_metrics)
   }
 
   dynamic "set" {
     for_each = var.enable_metrics ? [1] : []
     content {
       name  = "controller.metrics.secure"
-      value = var.metrics_secure_serving
+      value = tostring(var.metrics_secure_serving)
     }
   }
 

--- a/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/kmcp/main.tf
+++ b/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/kmcp/main.tf
@@ -28,6 +28,8 @@ resource "helm_release" "kmcp_crds" {
 
   skip_crds = false
   wait      = true
+  timeout   = 300
+  atomic    = true
 
   depends_on = [
     kubernetes_namespace.kmcp
@@ -44,6 +46,7 @@ resource "helm_release" "kmcp" {
   repository = "oci://ghcr.io/kagent-dev/kmcp/helm"
   version    = var.kmcp_version
   namespace  = kubernetes_namespace.kmcp.metadata[0].name
+  timeout    = 600
 
   # Controller replicas
   set {

--- a/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/kmcp/outputs.tf
+++ b/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/kmcp/outputs.tf
@@ -1,0 +1,43 @@
+#---------------------------------------------------------------
+# kmcp Module Outputs
+#---------------------------------------------------------------
+
+output "namespace" {
+  description = "kmcp Kubernetes namespace"
+  value       = kubernetes_namespace.kmcp.metadata[0].name
+}
+
+output "kmcp_version" {
+  description = "kmcp Helm chart version deployed"
+  value       = var.kmcp_version
+}
+
+output "controller_replicas" {
+  description = "Number of kmcp controller replicas"
+  value       = var.controller_replicas
+}
+
+output "metrics_service_name" {
+  description = "kmcp controller metrics service name"
+  value       = "kmcp-controller-metrics"
+}
+
+output "metrics_port" {
+  description = "kmcp controller metrics port"
+  value       = 8443
+}
+
+output "metrics_access_command" {
+  description = "kubectl port-forward command to access kmcp metrics locally"
+  value       = "kubectl port-forward -n ${kubernetes_namespace.kmcp.metadata[0].name} svc/kmcp-controller-metrics 8443:8443"
+}
+
+output "metrics_service_dns" {
+  description = "In-cluster DNS for kmcp metrics service (for Prometheus scrape configs)"
+  value       = "kmcp-controller-metrics.${kubernetes_namespace.kmcp.metadata[0].name}.svc.cluster.local:8443"
+}
+
+output "istio_injection_enabled" {
+  description = "Whether Istio sidecar injection is enabled for kmcp namespace"
+  value       = var.enable_istio_injection
+}

--- a/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/kmcp/variables.tf
+++ b/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/kmcp/variables.tf
@@ -12,16 +12,6 @@ variable "kmcp_version" {
   type        = string
 }
 
-variable "cluster_name" {
-  description = "EKS cluster name"
-  type        = string
-}
-
-variable "region" {
-  description = "AWS region"
-  type        = string
-}
-
 #---------------------------------------------------------------
 # Controller Configuration
 #---------------------------------------------------------------

--- a/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/kmcp/variables.tf
+++ b/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/kmcp/variables.tf
@@ -1,0 +1,117 @@
+#---------------------------------------------------------------
+# Required Variables
+#---------------------------------------------------------------
+
+variable "kmcp_namespace" {
+  description = "Kubernetes namespace for kmcp"
+  type        = string
+}
+
+variable "kmcp_version" {
+  description = "kmcp Helm chart version"
+  type        = string
+}
+
+variable "cluster_name" {
+  description = "EKS cluster name"
+  type        = string
+}
+
+variable "region" {
+  description = "AWS region"
+  type        = string
+}
+
+#---------------------------------------------------------------
+# Controller Configuration
+#---------------------------------------------------------------
+
+variable "controller_replicas" {
+  description = "Number of kmcp controller replicas"
+  type        = number
+  default     = 1
+  validation {
+    condition     = var.controller_replicas >= 1
+    error_message = "controller_replicas must be at least 1"
+  }
+}
+
+variable "controller_cpu_request" {
+  description = "CPU request for kmcp controller"
+  type        = string
+  default     = "100m"
+}
+
+variable "controller_memory_request" {
+  description = "Memory request for kmcp controller"
+  type        = string
+  default     = "128Mi"
+}
+
+variable "controller_cpu_limit" {
+  description = "CPU limit for kmcp controller"
+  type        = string
+  default     = "1000m"
+}
+
+variable "controller_memory_limit" {
+  description = "Memory limit for kmcp controller"
+  type        = string
+  default     = "512Mi"
+}
+
+#---------------------------------------------------------------
+# Leader Election
+#---------------------------------------------------------------
+
+variable "enable_leader_election" {
+  description = "Enable leader election for controller HA"
+  type        = bool
+  default     = true
+}
+
+#---------------------------------------------------------------
+# Metrics Configuration
+#---------------------------------------------------------------
+
+variable "enable_metrics" {
+  description = "Enable metrics endpoint on the controller"
+  type        = bool
+  default     = true
+}
+
+variable "metrics_secure_serving" {
+  description = "Enable secure (HTTPS) metrics serving"
+  type        = bool
+  default     = false
+}
+
+#---------------------------------------------------------------
+# Istio Sidecar Injection
+#---------------------------------------------------------------
+
+variable "enable_istio_injection" {
+  description = "Enable Istio sidecar injection for kmcp namespace"
+  type        = bool
+  default     = false
+}
+
+#---------------------------------------------------------------
+# Prometheus ServiceMonitor
+#---------------------------------------------------------------
+
+variable "enable_service_monitor" {
+  description = "Create a Prometheus ServiceMonitor for kmcp metrics (requires Prometheus Operator)"
+  type        = bool
+  default     = false
+}
+
+#---------------------------------------------------------------
+# Additional Helm Values
+#---------------------------------------------------------------
+
+variable "additional_helm_values" {
+  description = "Additional Helm values as YAML string to pass to kmcp chart"
+  type        = string
+  default     = ""
+}

--- a/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/kmcp/versions.tf
+++ b/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/kmcp/versions.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.20"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.9"
+    }
+  }
+}

--- a/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/outputs.tf
+++ b/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/outputs.tf
@@ -108,3 +108,17 @@ output "kagent_database_endpoint" {
   description = "PostgreSQL database endpoint for kagent (if using postgresql)"
   value       = var.kagent_enabled && var.kagent_database_type == "postgresql" ? module.kagent[0].database_endpoint : null
 }
+
+#---------------------------------------------------------------
+# kmcp Outputs
+#---------------------------------------------------------------
+
+output "kmcp_namespace" {
+  description = "kmcp Kubernetes namespace"
+  value       = var.kmcp_enabled ? module.kmcp[0].namespace : null
+}
+
+output "kmcp_metrics_access_command" {
+  description = "kubectl port-forward command to access kmcp metrics"
+  value       = var.kmcp_enabled ? module.kmcp[0].metrics_access_command : null
+}

--- a/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/variables.tf
+++ b/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/variables.tf
@@ -706,7 +706,7 @@ variable "kmcp_namespace" {
 variable "kmcp_version" {
   description = "kmcp Helm chart version"
   type        = string
-  default     = "1.0.0"
+  default     = "0.1.4"
 }
 
 variable "kmcp_controller_replicas" {

--- a/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/variables.tf
+++ b/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/variables.tf
@@ -687,4 +687,38 @@ variable "kagent_enable_istio_injection" {
   default     = false
 }
 
+#---------------------------------------------------------------
+# kmcp - Kubernetes MCP Server Controller
+#---------------------------------------------------------------
+
+variable "kmcp_enabled" {
+  description = "Enable kmcp (Kubernetes MCP Server Controller) deployment"
+  type        = bool
+  default     = false
+}
+
+variable "kmcp_namespace" {
+  description = "Kubernetes namespace for kmcp"
+  type        = string
+  default     = "kmcp-system"
+}
+
+variable "kmcp_version" {
+  description = "kmcp Helm chart version"
+  type        = string
+  default     = "1.0.0"
+}
+
+variable "kmcp_controller_replicas" {
+  description = "Number of kmcp controller replicas"
+  type        = number
+  default     = 1
+}
+
+variable "kmcp_enable_istio_injection" {
+  description = "Enable Istio sidecar injection for kmcp namespace"
+  type        = bool
+  default     = false
+}
+
 # END variables


### PR DESCRIPTION
Add kmcp as a new optional Terraform module for deploying and managing Model Context Protocol (MCP) servers as Kubernetes resources. kmcp is independent of kagent and can be enabled standalone.

- New module: kmcp/ with namespace, CRDs helm release, controller helm release
- Configurable controller replicas, resources, leader election, metrics
- Optional Prometheus ServiceMonitor (requires Prometheus Operator)
- Optional Istio sidecar injection (off by default)
- CRDs installed via separate helm release with wait=true for safe ordering
- Enable with: `terraform apply -var="kmcp_enabled=true"`

I validated the kmcp Terraform integration end-to-end. The PR successfully installs the kmcp CRDs and controller on EKS, registers the `MCPServer` CRD, and reconciles a sample `MCPServer` into a healthy Deployment and Running pod. The resource also transitions to `READY=True` after reconcile, confirming the integration is correct.

**Validation performed**

- Validated the `kmcp` Terraform integration end-to-end on EKS.
- Confirmed `kmcp-crds` and `kmcp` Helm releases deployed successfully
- Verified CRD registration for `mcpservers.kagent.dev`
- Verified `kmcp-controller-manager` is healthy in `kmcp-system`
- Created a sample `MCPServer` resource using `transportType: stdio`
- Verified the controller accepted and programmed the resource
- Verified reconciliation created a healthy Deployment and Running pod
- Verified the `MCPServer` reached `READY=True`

**Sample commands used for validation**
```
kubectl get crd | grep -i mcp
helm list -A | grep kmcp
kubectl get pods -n kmcp-system
kubectl get mcpservers
kubectl describe mcpserver my-fetch-server
kubectl get deployment -A | grep my-fetch-server
kubectl get pods -A | grep my-fetch-server
```

