### PR TITLE
Add helm chart for deploying BYO agents on kagent

### DIFF
--- a/examples/agentic/charts/byo-agent/Chart.yaml
+++ b/examples/agentic/charts/byo-agent/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: byo-agent
+description: Helm chart for deploying BYO (Bring Your Own) agents on kagent
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/examples/agentic/charts/byo-agent/examples/eks-ops-agent-values.yaml
+++ b/examples/agentic/charts/byo-agent/examples/eks-ops-agent-values.yaml
@@ -1,0 +1,31 @@
+# EKS Ops Agent - Example values for byo-agent chart
+#
+# Usage:
+#   helm install eks-ops-agent ./charts/byo-agent -f eks-ops-agent-values.yaml
+
+name: eks-ops-agent
+description: "EKS Operations Agent - manages and troubleshoots Amazon EKS clusters"
+
+image:
+  repository: "<AWS_ACCOUNT_ID>.dkr.ecr.us-west-2.amazonaws.com/eks-ops-agent"
+  tag: "0.1.0"
+
+env:
+  - name: AWS_REGION
+    value: "us-west-2"
+  - name: BEDROCK_MODEL_ID
+    value: "us.anthropic.claude-sonnet-4-20250514-v1:0"
+  - name: ENABLE_MCP_TOOLS
+    value: "false"
+  - name: ENABLE_MEMORY
+    value: "false"
+  - name: REDIS_URL
+    value: "redis://redis.kagent.svc.cluster.local:6379"
+
+resources:
+  requests:
+    memory: "512Mi"
+    cpu: "250m"
+  limits:
+    memory: "1Gi"
+    cpu: "500m"

--- a/examples/agentic/charts/byo-agent/templates/_helpers.tpl
+++ b/examples/agentic/charts/byo-agent/templates/_helpers.tpl
@@ -1,0 +1,32 @@
+{{/*
+Validate that the agent name ends in "-agent" (required by IRSA trust policy).
+*/}}
+{{- define "byo-agent.validateName" -}}
+{{- if not (hasSuffix "-agent" .Values.name) -}}
+{{- fail "agent name must end in '-agent' (required by IRSA trust policy)" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Validate required fields.
+*/}}
+{{- define "byo-agent.validateRequired" -}}
+{{- if not .Values.name -}}
+{{- fail "name is required" -}}
+{{- end -}}
+{{- if not .Values.description -}}
+{{- fail "description is required" -}}
+{{- end -}}
+{{- if not .Values.image.repository -}}
+{{- fail "image.repository is required" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Common labels.
+*/}}
+{{- define "byo-agent.labels" -}}
+app.kubernetes.io/name: {{ .Values.name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+{{- end -}}

--- a/examples/agentic/charts/byo-agent/templates/agent.yaml
+++ b/examples/agentic/charts/byo-agent/templates/agent.yaml
@@ -1,0 +1,24 @@
+{{- include "byo-agent.validateRequired" . -}}
+{{- include "byo-agent.validateName" . -}}
+apiVersion: kagent.dev/v1alpha2
+kind: Agent
+metadata:
+  name: {{ .Values.name }}
+  namespace: {{ .Values.namespace }}
+  labels:
+    {{- include "byo-agent.labels" . | nindent 4 }}
+spec:
+  description: {{ .Values.description | quote }}
+  type: BYO
+  byo:
+    deployment:
+      image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+      {{- if .Values.env }}
+      env:
+        {{- range .Values.env }}
+        - name: {{ .name }}
+          value: {{ .value | quote }}
+        {{- end }}
+      {{- end }}
+      resources:
+        {{- toYaml .Values.resources | nindent 8 }}

--- a/examples/agentic/charts/byo-agent/values.yaml
+++ b/examples/agentic/charts/byo-agent/values.yaml
@@ -1,0 +1,30 @@
+# BYO Agent - Default Values
+#
+# Required fields:
+#   name        - Agent name (must end in "-agent")
+#   description - Agent description (shown in kagent UI)
+#   image.repository - Container image URI (without tag)
+
+# Agent identity
+name: ""
+namespace: kagent
+description: ""
+
+# Container image
+image:
+  repository: ""
+  tag: "0.1.0"
+
+# Environment variables passed to the agent container
+env:
+  - name: AWS_REGION
+    value: "us-west-2"
+
+# Resource requests and limits
+resources:
+  requests:
+    memory: "512Mi"
+    cpu: "250m"
+  limits:
+    memory: "1Gi"
+    cpu: "500m"

--- a/examples/agentic/eks-ops-agent/README.md
+++ b/examples/agentic/eks-ops-agent/README.md
@@ -712,6 +712,62 @@ Agents must have names ending in `-agent` (e.g., `eks-ops-agent`, `my-custom-age
 
 ---
 
+## Deploying Additional BYO Agents
+
+> **Note:** This section is for deploying additional agents beyond the workshop. The workshop modules above use `build-and-deploy.sh` which handles the full lifecycle (build, push, deploy, IRSA). The Helm chart below is for teams that want a standardized way to deploy multiple BYO agents.
+
+A generic Helm chart is available at [`examples/agentic/charts/byo-agent/`](../charts/byo-agent/) for deploying any BYO agent on kagent. It templatizes the Agent CRD so you can deploy different agents by providing a `values.yaml` file.
+
+### Usage
+
+```bash
+# Deploy using a values file
+helm install my-agent ./examples/agentic/charts/byo-agent -f my-agent-values.yaml
+
+# Upgrade (e.g., new image tag)
+helm upgrade my-agent ./examples/agentic/charts/byo-agent -f my-agent-values.yaml --set image.tag=0.2.0
+
+# Uninstall
+helm uninstall my-agent
+```
+
+### Example values file
+
+See [`charts/byo-agent/examples/eks-ops-agent-values.yaml`](../charts/byo-agent/examples/eks-ops-agent-values.yaml) for a complete example. A minimal values file looks like:
+
+```yaml
+name: my-custom-agent          # Must end in "-agent"
+description: "My Custom Agent"
+image:
+  repository: 123456789.dkr.ecr.us-west-2.amazonaws.com/my-custom-agent
+  tag: "0.1.0"
+env:
+  - name: AWS_REGION
+    value: "us-west-2"
+  - name: BEDROCK_MODEL_ID
+    value: "us.anthropic.claude-sonnet-4-20250514-v1:0"
+```
+
+### What the Helm chart does and does not do
+
+| Handled by Helm chart | Handled separately |
+|------------------------|--------------------|
+| Agent CRD deployment | Container build and ECR push |
+| Environment variables | IRSA annotation (`build-and-deploy.sh`) |
+| Resource limits | Redis or other dependencies |
+| Agent name validation | kagent controller (deployed via Terraform) |
+
+After `helm install`, you still need to annotate the ServiceAccount for IRSA:
+
+```bash
+AGENT_NAME=my-custom-agent
+BEDROCK_ROLE_ARN=arn:aws:iam::<ACCOUNT_ID>:role/<CLUSTER_NAME>-kagent-bedrock-role
+kubectl annotate sa $AGENT_NAME -n kagent eks.amazonaws.com/role-arn=$BEDROCK_ROLE_ARN
+kubectl rollout restart deployment $AGENT_NAME -n kagent
+```
+
+---
+
 ## Troubleshooting
 
 ### Check agent status

--- a/examples/agentic/eks-ops-agent/eks-ops-agent-workshop.ipynb
+++ b/examples/agentic/eks-ops-agent/eks-ops-agent-workshop.ipynb
@@ -974,6 +974,12 @@
     "!kubectl get pods -n kagent -l kagent=eks-ops-agent\n",
     "!kubectl logs -n kagent -l kagent=eks-ops-agent --tail=50"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "muutvkndqe",
+   "source": "---\n## Next Steps: Deploying Additional Agents\n\nThis workshop used `build-and-deploy.sh` to handle the full agent lifecycle (build, push, deploy, IRSA). For deploying multiple BYO agents in a standardized way, a generic Helm chart is available at `examples/agentic/charts/byo-agent/`. See the [README](README.md#deploying-additional-byo-agents) for details.",
+   "metadata": {}
   }
  ],
  "metadata": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds a generic, reusable Helm chart that templatizes the kagent Agent CRD for deploying BYO agents.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
