### PR TITLE
Eks version bump to kubernetes 1.35

### DIFF
--- a/docs/upgrade-1.35.md
+++ b/docs/upgrade-1.35.md
@@ -1,0 +1,184 @@
+# EKS Upgrade Ledger: 1.33 → 1.35
+
+**Branch:** `eks-version-bump`
+**Initiated:** 2026-06-23
+**Target Kubernetes:** 1.35 (EKS standard support through 2027-03-26)
+**Original target:** 1.36 — see [Why not 1.36?](#why-not-136) below.
+
+This document is the canonical reference for what was changed and why. If something breaks during testing, start here.
+
+## Why not 1.36?
+
+K8s 1.36 went GA on EKS in June 2026, but two controllers in our stack don't yet have GA support:
+
+| Controller | Latest GA | Supports K8s 1.36? | Status |
+|---|---|---|---|
+| `cluster-autoscaler` image | v1.35.0 | ❌ no `v1.36.x` published on `registry.k8s.io/autoscaling/cluster-autoscaler` | upstream pending |
+| `cert-manager` | 1.20.2 | ❌ matrix tops out at K8s 1.35 | 1.21.x only in alpha as of 2026-06-23 |
+
+We can revisit 1.36 once cert-manager 1.21 GA and CA v1.36.x ship. Both are likely within weeks.
+
+## In-scope categories
+
+- EKS cluster Kubernetes version
+- EKS managed addons (the four we pin and the one we add)
+- Kubernetes-API-coupled controllers (Karpenter, Istio, ALB controller, cert-manager, etc.)
+- Helm provider versions in `versions.tf`
+
+## Explicitly out of scope (separate follow-up PRs)
+
+- Local Helm chart versions in `charts/` (mpi-operator, pv-efs, kubeflow-*, etc.) — unrelated to K8s version
+- ML container base images (PyTorch 24.01, Ray 2.52.1, TF 2.12.0, DeepSpeed 0.13.4, vllm-neuron 0.3.0, etc.)
+- HyperPod CLI bundled chart deps (pinned upstream by SageMaker HyperPod, do not touch)
+- Major-version Helm jumps deferred until after 1.35 lands cleanly:
+  - AWS LB Controller chart `v3.x` (currently on `1.x` line)
+  - `terraform-aws-modules/iam` v6.x (currently `1.x`)
+  - `terraform-aws-modules/eks/aws` karpenter submodule v21.x (currently `20.x`)
+  - kube-prometheus-stack 87.x (currently `60.x`) — has CRD migrations
+  - oauth2-proxy chart 10.x (currently `6.x`)
+  - cert-manager 1.21 (currently `1.13.x`) — alpha only as noted above
+
+## Version table
+
+Columns: **Current** = what's on master. **Target** = what this PR sets. **Latest as of 2026-06-23** = what's in upstream right now. **Notes** = anything load-bearing.
+
+### 1. EKS control plane
+
+| Component | Current | Target | Latest | Notes |
+|---|---|---|---|---|
+| Kubernetes version (default in `variables.tf`) | 1.33 | **1.35** | 1.36 | See [Why not 1.36?](#why-not-136) |
+| K8s version fallback in `main.tf:325` (locals.use_k8s_version) | "1.33" | **"1.35"** | — | Used when user passes "1.1*" pre-validation |
+
+### 2. EKS managed addons (`aws_eks_addon`)
+
+| Addon | Current | Target | Latest for 1.35 | Notes |
+|---|---|---|---|---|
+| aws-ebs-csi-driver | `v1.33.0-eksbuild.1` | **`v1.62.0-eksbuild.1`** | v1.62.0-eksbuild.1 | Currently the only managed addon pinned in TF. Others (VPC CNI / kube-proxy / CoreDNS) install with EKS defaults at cluster create time. |
+
+**Decision:** keep only the EBS CSI addon explicitly pinned, matching repo's current pattern. Adding VPC CNI / kube-proxy / CoreDNS / EFS CSI as managed addons is a larger architectural change deferred to a separate PR.
+
+### 3. Worker node AMI types
+
+| Nodegroup | Current | Target | Notes |
+|---|---|---|---|
+| system | `AL2023_x86_64_STANDARD` | **unchanged** | AMI type, not AMI ID — EKS picks the latest 1.35-compatible AL2023 AMI automatically |
+| nvidia | `AL2023_x86_64_NVIDIA` | **unchanged** | same |
+| neuron | `AL2023_x86_64_NEURON` | **unchanged** | same |
+
+No AMI ID is pinned. The `AL2023_x86_64_*` references resolve at cluster create time to the latest AMI for the configured K8s version. **Mismatch risk:** none.
+
+### 4. Kubernetes-API-coupled Helm charts
+
+| Chart | Current | Target | Latest | K8s 1.35 supported? | Notes |
+|---|---|---|---|---|---|
+| AWS Load Balancer Controller | `v1.13.2` | **`v1.17.1`** | 1.17.1 (in 1.x line); 3.4.0 in newer line | ✅ | Stay in 1.x line; v3.x is a separate major refactor |
+| AWS EFS CSI Driver (Helm) | `3.1.7` | **`3.4.1`** | 4.3.0 | ✅ | Stay in 3.x line; v4 deferred |
+| AWS FSx CSI Driver | `1.10.0` | **`1.17.0`** | 1.17.0 | ✅ | Same major, safe |
+| EKS Blueprints Addons (TF module) | `1.21.0` | **`1.23.0`** | 1.23.0 | ✅ | Same major |
+| IAM role for SA EKS (TF module) | `1.1.1` | **unchanged** | 6.6.1 (major rewrite) | n/a | v6.x has breaking input/output schema changes — deferred |
+| cert-manager (Helm) | `1.13.3` | **`1.20.2`** | 1.20.2 GA / 1.21.0-alpha.x | ✅ | Skipping forward several minors; 1.21 alpha not safe |
+| cluster-autoscaler (chart) | `9.46.6` | **`9.58.0`** | 9.58.0 | ✅ | Chart bump + image tag override below |
+| cluster-autoscaler (image tag override) | (chart default) | **`v1.35.0`** | v1.35.0 | ✅ | Must match cluster K8s minor |
+| Karpenter (Helm: karpenter + karpenter-crd) | `1.6.3` (var.karpenter_version default) | **`1.13.0`** | 1.13.0 | ✅ | Karpenter 1.13 compat matrix explicitly lists K8s 1.35 |
+| Karpenter (TF module) | `20.37.0` | **stay in 20.x latest patch** | 21.23.0 (major) | n/a | v21 has breaking schema; in-major patch only |
+| Istio (base, istiod, cni, ingress) | `1.26.0` | **`1.30.1`** | 1.30.1 | ✅ | 1.30 compat matrix lists K8s 1.32–1.36 |
+| EFA Device Plugin (eks-charts) | `v0.4.4` | **`v0.5.29`** | v0.5.29 | ✅ | Chart still lives at `aws.github.io/eks-charts`. Earlier flag retracted after re-checking index. |
+
+### 5. K8s-adjacent Helm charts (bumped to current major's latest patch)
+
+| Chart | Current | Target | Latest in same major |
+|---|---|---|---|
+| kube-prometheus-stack | `60.3.0` | **`60.5.0`** | 60.5.0 (87.1.0 in new major, deferred) |
+| Kueue | `0.11.4` | **unchanged** | 0.18.1 — defer (no K8s-version coupling) |
+| DCGM Exporter | `4.0.4` | **unchanged** | 4.8.2 — defer |
+| OAuth2 Proxy | `6.23.1` | **unchanged** | 10.7.0 (major) — defer |
+| KServe | `v0.15.1` | **unchanged** | v0.19.0 — defer |
+| Airflow | `1.16.0` | **unchanged** | 1.22.0 — defer |
+| ACK SageMaker Controller | `1.2.15` | **unchanged** | v1.8.0 — defer |
+| MLflow | `0.17.2` | **unchanged** | 1.11.2 (major) — defer |
+| kagent | `0.7.11` | **unchanged** | 0.9.9 — defer |
+| kmcp | `0.1.4` | **unchanged** | 0.3.0 — defer |
+| KubeRay Operator | `1.4.2` | **unchanged** | chart still 1.4.2 |
+| LWS image | `v0.7.0` | **unchanged** | v0.9.0 — defer |
+| mpi-operator image | `0.4.0` | **unchanged** | v0.8.0 — defer |
+
+These are bumped only if K8s 1.35 breaks them. None do, per their compat matrices. Defer the upgrades.
+
+### 6. Terraform/Helm provider versions (`versions.tf`)
+
+| Provider | Current | Target | Notes |
+|---|---|---|---|
+| terraform | `>= 1.5.1` | **unchanged** | fine |
+| hashicorp/aws | `>= 2.7.0` | **unchanged** | very loose, latest will resolve |
+| hashicorp/helm | `~> 2.17.0` | **unchanged** | fine |
+| gavinbunney/kubectl | `>= 1.14.0` | **unchanged** | fine |
+| hashicorp/awscc | `>= 1.0.0` | **unchanged** | fine |
+
+## Mismatches / risks to watch during testing
+
+1. ~~**EFA Device Plugin chart**~~ — resolved. Chart is at `aws.github.io/eks-charts` exactly where TF expects it; latest `v0.5.29` flows in cleanly.
+
+2. **Karpenter minor-skip (1.6.3 → 1.13.0)** — within the same Karpenter v1 line but 7 minor versions apart. Karpenter has had non-breaking CRD evolution; should be safe, but Karpenter docs recommend a rolling upgrade rather than skipping versions on a live cluster. **Action for testing:** verify on a fresh cluster, not via in-place upgrade.
+
+3. **Istio minor-skip (1.26 → 1.30)** — 4 minor versions. Istio's policy is N to N+2 supported in-place; we are jumping further. **Action for testing:** install fresh, do not in-place upgrade.
+
+4. **cert-manager minor-skip (1.13 → 1.20)** — 7 minor versions. Webhook/CRD compatibility historically maintained across minors but **CRD migrations may be required**. **Action for testing:** apply CRD bundles in order if upgrading in place; on fresh install, no concern.
+
+5. **ALB Controller (1.13 → 1.17)** — same major, but TargetGroupBinding CRD spec adds/removes fields between minors. **Action for testing:** confirm existing TargetGroupBinding resources still reconcile.
+
+6. **Cluster Autoscaler image tag override** — chart 9.58.0 defaults to a `v1.34.x` image. We added an explicit `image.tag: v1.35.0` to the values block in `main.tf` cluster-autoscaler helm_release so it matches the cluster's K8s minor.
+
+7. **Submodule helm provider pin** (`istio/`, `kubeflow/`, `hyperpod/`, `kagent/`, `kmcp/`) — these submodules previously had no helm provider pin or a loose `>= 2.9`, both of which resolve to `helm@3.x` on a fresh `terraform init`. The `aws-ia/eks-blueprints-addon@1.1.1` they use is incompatible with helm v3 block syntax. Pinned all five to `~> 2.17.0` matching the root module to make `terraform validate` work on master. **Pre-existing failure on master** — would have broken anyone doing a fresh init. Side-effect benefit of this PR.
+
+## Validation plan (what should happen before merge)
+
+- [x] `terraform validate` passes on root module (warnings only — pre-existing `data.aws_region.name` deprecation, unrelated)
+- [x] `terraform validate` passes on `istio/`
+- [x] `terraform validate` passes on `kubeflow/`
+- [x] `terraform validate` passes on `slurm/`
+- [x] `terraform validate` passes on `mlflow/`
+- [x] `terraform validate` passes on `kagent/`
+- [x] `terraform validate` passes on `kmcp/`
+- [x] `terraform validate` passes on `hyperpod/`
+- [ ] `terraform fmt` pass
+- [ ] Manual smoke test on a non-production cluster: spin up `terraform apply`, exercise the demo scenarios from `examples/agentic/aws-devops-agent-demo` against the new cluster
+- [ ] Spot-check that ALB Controller, cert-manager, Istio, Karpenter all reconcile after install
+
+## Rollback
+
+Each file changed in this PR is independently reversible. If a single controller version proves problematic, just bump that one back. If the cluster K8s upgrade itself misbehaves, revert the `k8s_version` default and the `use_k8s_version` fallback — those two lines.
+
+## Changelog
+
+All changes on branch `eks-version-bump`, off `master`, 2026-06-23.
+
+### `eks-cluster/terraform/aws-eks-cluster-and-nodegroup/variables.tf`
+- `k8s_version` default: `1.33` → `1.35`
+- `karpenter_version` default: `1.6.3` → `1.13.0`
+- `prometheus_version` default: `60.3.0` → `60.5.0`
+
+### `eks-cluster/terraform/aws-eks-cluster-and-nodegroup/main.tf`
+- `locals.use_k8s_version` fallback: `"1.33"` → `"1.35"`
+- `module.eks_blueprints_addons` version: `1.21.0` → `1.23.0`
+- `aws_load_balancer_controller.chart_version`: `v1.13.2` → `1.17.1` (also dropped the leading `v` to match the chart's index format)
+- `aws_efs_csi_driver.chart_version`: `3.1.7` → `3.4.1`
+- `aws_fsx_csi_driver.chart_version`: `1.10.0` → `1.17.0`
+- `eks_addons.aws-ebs-csi-driver.addon_version`: `v1.33.0-eksbuild.1` → `v1.62.0-eksbuild.1`
+- `helm_release.cert-manager.chart_version`: `1.13.3` → `1.20.2`
+- `helm_release.cluster-autoscaler.version`: `9.46.6` → `9.58.0`
+- `helm_release.cluster-autoscaler.values`: added `image.tag: "v1.35.0"` (chart default tracks one K8s minor behind; must match cluster)
+- `helm_release.aws-efa-k8s-device-plugin.version`: `v0.4.4` → `v0.5.29`
+- `locals.istio_repo_version` (line 1272): `1.26.0` → `1.30.1`
+
+### `eks-cluster/terraform/aws-eks-cluster-and-nodegroup/istio/main.tf`
+- `locals.istio_repo_version`: `1.26.0` → `1.30.1`
+
+### Submodule helm provider pins (unblock `terraform validate`)
+- `istio/versions.tf`: added `hashicorp/helm ~> 2.17.0`
+- `kubeflow/versions.tf`: added `hashicorp/helm ~> 2.17.0`
+- `hyperpod/versions.tf`: added `hashicorp/helm ~> 2.17.0`
+- `kagent/versions.tf`: tightened `hashicorp/helm` from `>= 2.9` to `~> 2.17.0`
+- `kmcp/versions.tf`: tightened `hashicorp/helm` from `>= 2.9` to `~> 2.17.0`
+
+### Net files changed: 9
+### Net lines: ~30 (most are 1-line value edits)

--- a/docs/upgrade-1.35.md
+++ b/docs/upgrade-1.35.md
@@ -130,19 +130,71 @@ These are bumped only if K8s 1.35 breaks them. None do, per their compat matrice
 
 7. **Submodule helm provider pin** (`istio/`, `kubeflow/`, `hyperpod/`, `kagent/`, `kmcp/`) — these submodules previously had no helm provider pin or a loose `>= 2.9`, both of which resolve to `helm@3.x` on a fresh `terraform init`. The `aws-ia/eks-blueprints-addon@1.1.1` they use is incompatible with helm v3 block syntax. Pinned all five to `~> 2.17.0` matching the root module to make `terraform validate` work on master. **Pre-existing failure on master** — would have broken anyone doing a fresh init. Side-effect benefit of this PR.
 
-## Validation plan (what should happen before merge)
+## Validation plan + results
 
-- [x] `terraform validate` passes on root module (warnings only — pre-existing `data.aws_region.name` deprecation, unrelated)
-- [x] `terraform validate` passes on `istio/`
-- [x] `terraform validate` passes on `kubeflow/`
-- [x] `terraform validate` passes on `slurm/`
-- [x] `terraform validate` passes on `mlflow/`
-- [x] `terraform validate` passes on `kagent/`
-- [x] `terraform validate` passes on `kmcp/`
-- [x] `terraform validate` passes on `hyperpod/`
+- [x] `terraform validate` passes on root + all 7 submodules (warnings only — pre-existing `data.aws_region.name` and `kubernetes_namespace` deprecations, unrelated to this PR)
 - [ ] `terraform fmt` pass
-- [ ] Manual smoke test on a non-production cluster: spin up `terraform apply`, exercise the demo scenarios from `examples/agentic/aws-devops-agent-demo` against the new cluster
-- [ ] Spot-check that ALB Controller, cert-manager, Istio, Karpenter all reconcile after install
+- [x] **Real `terraform apply` on a test cluster (`<YOUR_TEST_CLUSTER>`, us-west-2)** — see "Test results" below
+- [x] Smoke test: 10 phases all PASS — see "Test results" below
+
+## Test results — `<YOUR_TEST_CLUSTER>` apply 2026-06-23
+
+Greenfield bring-up against a fresh cluster (separate worktree, separate S3 backend, no shared state with any other cluster).
+
+### Apply summary
+
+- **Plan:** 140 to add, 0 to change, 0 to destroy.
+- **Apply attempt 1:** 137/140 created. 3 failures, all timing-related (downstream Helm releases tried to install before ALB controller webhook was Ready).
+- **Apply attempt 2 (idempotent retry):** 2 of the 3 reconciled cleanly. 1 remaining failure: `kubeflow-tensorboards`.
+- **Final state:** cluster ACTIVE on K8s 1.35, every K8s-coupled controller Running, 139/140 resources successfully managed.
+
+### Verified working at the bumped versions
+
+| Component | Pinned version | Live state |
+|---|---|---|
+| EKS control plane | 1.35 | ACTIVE |
+| System nodegroup | (AL2023_x86_64_STANDARD) | 8/8 nodes Ready |
+| EBS CSI managed addon | `v1.62.0-eksbuild.1` | ACTIVE |
+| AWS Load Balancer Controller | `1.17.1` chart | 2/2 Running |
+| AWS EFS CSI Driver | `3.4.1` chart | landed |
+| AWS FSx CSI Driver | `1.17.0` chart | landed |
+| cert-manager | `1.20.2` chart | Running |
+| Cluster Autoscaler | `9.58.0` chart + `v1.35.0` image override | Running with **image: `registry.k8s.io/autoscaling/cluster-autoscaler:v1.35.0`** ✓ matches cluster K8s minor |
+| Karpenter | `1.13.0` chart | 2/2 Running in `kube-system`, 4 NodePools registered |
+| Istio (base / istiod / cni / ingress) | `1.30.1` | istiod Running, CRDs present |
+| EKS Blueprints Addons module | `1.23.0` | rendered cleanly |
+| kube-prometheus-stack | `60.5.0` | rendered (operator + alertmanager) |
+| EKS EFA Device Plugin | `v0.5.29` chart | installed (no EFA-capable nodes yet, daemonset waiting) |
+| Kubeflow (training, katib, pipelines, notebooks, kuberay, mpi-operator, profiles, etc.) | various | 29 pods Running across the namespace |
+| kagent | `0.7.11` | 16 pods Running in `kagent` namespace |
+| Submodule helm provider pins (~> 2.17.0) | — | terraform init+plan+apply all clean |
+
+### Smoke test (`smoke-test-1.35.sh`)
+
+Ran in the worktree after apply. All 10 phases PASS:
+
+1. ✅ kubeconfig updated
+2. ✅ Control plane reachable, server reports `v1.35`
+3. ✅ 8/8 nodes Ready
+4. ✅ EBS CSI managed addon ACTIVE
+5. ✅ ALB controller, cert-manager, CA, Karpenter, istiod all Running
+6. ✅ CA image is `v1.35.0` (exact)
+7. ✅ Kubeflow namespace populated (29 pods)
+8. ✅ kagent namespace healthy (16 pods)
+9. ✅ Karpenter NodePools (4) registered
+10. ✅ CRDs present for cert-manager, ALB Controller, Karpenter, Istio
+
+### Issues found during the live apply
+
+| # | Issue | Root cause | Recommendation |
+|---|---|---|---|
+| 1 | `helm_release.prometheus` failed on first apply (webhook race) | ALB controller webhook not yet Ready when prometheus tried to install | Resolved by re-running `terraform apply`. Long-term: add explicit `depends_on aws_load_balancer_controller` to prometheus. Tracker for follow-up PR. |
+| 2 | `kubernetes_namespace.auth` failed on first apply | Same webhook race | Same as #1, resolved on retry. |
+| 3 | `kubeflow-tensorboards` chart fails apply, even on retry | Chart references `gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0` which **no longer exists upstream** (gcr.io pruned this image). Confirmed via `kubectl describe pod`. | **NOT caused by this PR.** Same chart on master against K8s 1.33 would hit the same error. Track as a separate follow-up — bump kubeflow-tensorboards chart to a version that uses a current rbac-proxy image (e.g. `registry.k8s.io/kube-rbac-proxy` or `quay.io/brancz/kube-rbac-proxy`). |
+
+### Helm-release versions in cluster (`helm list -A`)
+
+The full list from the live cluster confirmed every Helm release this PR touched landed at the expected version. The only `failed` row in `helm list` is `kubeflow-tensorboards` (issue #3 above).
 
 ## Rollback
 

--- a/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/hyperpod/versions.tf
+++ b/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/hyperpod/versions.tf
@@ -1,4 +1,10 @@
 terraform {
   required_version = ">= 1.5.1"
 
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.17.0"
+    }
+  }
 }

--- a/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/istio/main.tf
+++ b/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/istio/main.tf
@@ -1,6 +1,6 @@
 locals {
   istio_repo_url = "https://istio-release.storage.googleapis.com/charts"
-  istio_repo_version = "1.26.0"
+  istio_repo_version = "1.30.1"
 }
 
 module "istio_base" {

--- a/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/istio/versions.tf
+++ b/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/istio/versions.tf
@@ -11,5 +11,10 @@ terraform {
       source  = "gavinbunney/kubectl"
       version = ">= 1.14.0"
     }
+
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.17.0"
+    }
   }
 }

--- a/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/kagent/versions.tf
+++ b/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/kagent/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.9"
+      version = "~> 2.17.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/kmcp/versions.tf
+++ b/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/kmcp/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.9"
+      version = "~> 2.17.0"
     }
   }
 }

--- a/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/kubeflow/versions.tf
+++ b/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/kubeflow/versions.tf
@@ -11,5 +11,10 @@ terraform {
       source  = "gavinbunney/kubectl"
       version = ">= 1.14.0"
     }
+
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.17.0"
+    }
   }
 }

--- a/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/main.tf
+++ b/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/main.tf
@@ -322,7 +322,7 @@ resource "aws_fsx_data_repository_association" "this" {
 }
 
 locals {
-  use_k8s_version = substr(var.k8s_version, 0, 3) == "1.1" ? "1.33" : var.k8s_version
+  use_k8s_version = substr(var.k8s_version, 0, 3) == "1.1" ? "1.35" : var.k8s_version
   s3_bucket       = split("/", substr(var.import_path, 5, -1))[0]
 }
 
@@ -432,7 +432,7 @@ module "ebs_csi_driver_irsa" {
 module "eks_blueprints_addons" {
 
   source  = "aws-ia/eks-blueprints-addons/aws"
-  version = "1.21.0"
+  version = "1.23.0"
 
   cluster_name      = aws_eks_cluster.eks_cluster.id
   cluster_endpoint  = aws_eks_cluster.eks_cluster.endpoint
@@ -446,7 +446,7 @@ module "eks_blueprints_addons" {
 
   aws_load_balancer_controller = {
     namespace     = "kube-system"
-    chart_version = "v1.13.2"
+    chart_version = "1.17.1"
     wait          = true
 
     set = [
@@ -459,17 +459,17 @@ module "eks_blueprints_addons" {
 
   aws_efs_csi_driver = {
     namespace     = "kube-system"
-    chart_version = "3.1.7"
+    chart_version = "3.4.1"
   }
 
   aws_fsx_csi_driver = {
     namespace     = "kube-system"
-    chart_version = "1.10.0"
+    chart_version = "1.17.0"
   }
 
   eks_addons = {
     aws-ebs-csi-driver = {
-      addon_version            = "v1.33.0-eksbuild.1"
+      addon_version            = "v1.62.0-eksbuild.1"
       service_account_role_arn = module.ebs_csi_driver_irsa.iam_role_arn
     }
   }
@@ -513,7 +513,7 @@ module "cert_manager" {
   namespace        = "cert-manager"
   create_namespace = true
   chart            = "cert-manager"
-  chart_version    = "1.13.3"
+  chart_version    = "1.20.2"
   repository       = "https://charts.jetstack.io"
 
   wait = true
@@ -628,7 +628,7 @@ resource "helm_release" "cluster-autoscaler" {
   name       = "cluster-autoscaler"
   repository = "https://kubernetes.github.io/autoscaler"
   chart      = "cluster-autoscaler"
-  version    = "9.46.6"
+  version    = "9.58.0"
   namespace  = "kube-system"
   timeout    = 300
   wait       = true
@@ -639,6 +639,8 @@ resource "helm_release" "cluster-autoscaler" {
       awsRegion: "${var.region}"
       autoDiscovery:
         clusterName: "${aws_eks_cluster.eks_cluster.id}"
+      image:
+        tag: "v1.35.0"
       extraArgs:
         skip-nodes-with-system-pods: "false"
         skip-nodes-with-local-storage: "false"
@@ -649,7 +651,7 @@ resource "helm_release" "cluster-autoscaler" {
       rbac:
         serviceAccount:
           annotations:
-            eks.amazonaws.com/role-arn: "${aws_iam_role.cluster_autoscaler.arn}" 
+            eks.amazonaws.com/role-arn: "${aws_iam_role.cluster_autoscaler.arn}"
     EOT
   ]
 
@@ -661,7 +663,7 @@ resource "helm_release" "aws-efa-k8s-device-plugin" {
   name       = "aws-efa-k8s-device-plugin"
   repository = "https://aws.github.io/eks-charts"
   chart      = "aws-efa-k8s-device-plugin"
-  version    = "v0.4.4"
+  version    = "v0.5.29"
   namespace  = "kube-system"
 
 
@@ -1269,7 +1271,7 @@ module "istio" {
 
 locals {
   istio_repo_url     = "https://istio-release.storage.googleapis.com/charts"
-  istio_repo_version = "1.26.0"
+  istio_repo_version = "1.30.1"
 }
 
 resource "kubernetes_namespace" "ingress" {

--- a/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/variables.tf
+++ b/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/variables.tf
@@ -25,7 +25,7 @@ variable "eks_admin_role_arn" {
 
 variable "k8s_version" {
   description = "kubernetes version"
-  default = "1.33"
+  default = "1.35"
   type    = string
 }
 
@@ -267,7 +267,7 @@ variable "karpenter_namespace" {
 variable "karpenter_version" {
   description = "Karpenter version"
   type = string
-  default = "1.6.3"
+  default = "1.13.0"
 }
 
 variable "karpenter_capacity_type" {
@@ -303,7 +303,7 @@ variable "prometheus_namespace" {
 variable "prometheus_version" {
   description = "Prometheus community kube-prometheus-stack chart version"
   type = string
-  default = "60.3.0"
+  default = "60.5.0"
 }
 
 variable "nvidia_plugin_version" {


### PR DESCRIPTION
## Summary

Upgrades the cluster Kubernetes version from 1.33 to **1.35** and coordinates all Kubernetes-API-coupled controllers to versions that explicitly support 1.35.

Live-apply validated on a test cluster (us-west-2): cluster ACTIVE on 1.35, 8/8 nodes Ready, every controller Running at the new pinned version, all smoke tests pass. Details in `docs/upgrade-1.35.md`.

## Why 1.35 and not 1.36?

K8s 1.36 went GA on EKS in June 2026, but two controllers in this stack don't yet have GA support:

- **cert-manager**: 1.20 supports up to K8s 1.35; 1.21 (which supports 1.36) is alpha only.
- **Cluster Autoscaler**: `v1.36.x` image has not been published on `registry.k8s.io/autoscaling/cluster-autoscaler`.

1.35 has EKS standard support through 2027-03-26 with every controller in this repo fully supported.

## What's bumped

| Component | From | To |
|---|---|---|
| Kubernetes (cluster + fallback) | 1.33 | **1.35** |
| EBS CSI managed addon | v1.33.0 | **v1.62.0-eksbuild.1** |
| AWS Load Balancer Controller | v1.13.2 | **1.17.1** |
| AWS EFS CSI Driver (Helm) | 3.1.7 | **3.4.1** |
| AWS FSx CSI Driver | 1.10.0 | **1.17.0** |
| EKS Blueprints Addons module | 1.21.0 | **1.23.0** |
| cert-manager | 1.13.3 | **1.20.2** |
| Cluster Autoscaler (chart) | 9.46.6 | **9.58.0** |
| Cluster Autoscaler (image tag) | (chart default) | **v1.35.0** explicit override |
| Karpenter (Helm) | 1.6.3 | **1.13.0** |
| Istio | 1.26.0 | **1.30.1** |
| AWS EFA Device Plugin | v0.4.4 | **v0.5.29** |
| kube-prometheus-stack | 60.3.0 | **60.5.0** |

## Side fix

Pinned the `hashicorp/helm` provider to `~> 2.17.0` in the `istio`, `kubeflow`, `hyperpod`, `kagent`, and `kmcp` submodules. Without that pin, `terraform init` resolves helm 3.x — which is incompatible with the `aws-ia/eks-blueprints-addon@1.1.1` module's `set`/`set_sensitive` block syntax, breaking `terraform validate` even on master.

## Out of scope (separate follow-up PRs)

- Major-version Helm jumps: ALB Controller v3, `terraform-aws-modules/iam` v6, `terraform-aws-modules/eks` karpenter submodule v21, kube-prometheus-stack 87, oauth2-proxy 10, MLflow 1.x
- K8s-adjacent charts without K8s-version coupling (Kueue, KServe, Airflow, DCGM, KubeRay, kagent app, kmcp, LWS, mpi-operator image)
- ML container base images (PyTorch, Ray, TensorFlow, DeepSpeed, vLLM, etc.)
- HyperPod CLI bundled chart dependencies (pinned upstream by SageMaker HyperPod)

## Test plan

- [x] `terraform validate` passes on root + all 7 submodules (warnings are pre-existing, unrelated)
- [x] Real `terraform apply` on a greenfield test cluster (separate worktree, separate S3 backend, no shared state)
- [x] Smoke test: 10 phases all PASS (K8s version, nodes Ready, EBS CSI ACTIVE, ALB/cert-manager/CA/Karpenter/Istio Running, CA image tag exact match, Kubeflow + kagent namespaces populated, NodePools registered, controller CRDs present)
- [x] Verified `cluster-autoscaler:v1.35.0` is the running image tag

## Known pre-existing issue surfaced (not caused by this PR)

`kubeflow-tensorboards` Helm release fails because the chart references `gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0`, which has been pruned from gcr.io upstream. Same chart on master against K8s 1.33 hits the same error. Should be tracked separately — bump kubeflow-tensorboards chart to use a current rbac-proxy image (e.g. from `registry.k8s.io` or `quay.io/brancz/`).

## Reference

`docs/upgrade-1.35.md` is the full upgrade ledger: per-component version table, mismatch flags, validation results, rollback notes, and detailed test results from the live apply.
