### PR TITLE
Workshop fixes: kubeflow-tensorboards rbac-proxy image + eks-ops-agent a2a-sdk pin

### DIFF
--- a/charts/ml-platform/kubeflow-tensorboards/Chart.yaml
+++ b/charts/ml-platform/kubeflow-tensorboards/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: v1.9.2
 description: A Helm chart for Kubeflow tensorboards
 name: kubeflow-tensorboards
 type: application
-version: 1.0.0
+version: 1.0.1

--- a/charts/ml-platform/kubeflow-tensorboards/templates/controller/deployment.yaml
+++ b/charts/ml-platform/kubeflow-tensorboards/templates/controller/deployment.yaml
@@ -57,7 +57,7 @@ spec:
         - --upstream=http://127.0.0.1:8080/
         - --logtostderr=true
         - --v=0
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0
+        image: quay.io/brancz/kube-rbac-proxy:v0.19.1
         name: kube-rbac-proxy
         ports:
         - containerPort: 8443

--- a/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/kubeflow/main.tf
+++ b/eks-cluster/terraform/aws-eks-cluster-and-nodegroup/kubeflow/main.tf
@@ -244,7 +244,7 @@ resource "helm_release" "kubeflow-tensorboards" {
 
   name       = "kubeflow-tensorboards"
   chart      = "${var.local_helm_repo}/ml-platform/kubeflow-tensorboards"
-  version  = "1.0.0"
+  version  = "1.0.1"
   namespace = var.kubeflow_namespace
 
   values = [

--- a/examples/agentic/eks-ops-agent/pyproject.toml
+++ b/examples/agentic/eks-ops-agent/pyproject.toml
@@ -9,6 +9,9 @@ dependencies = [
     "langchain-core>=0.3.28",
     "kagent-core==0.7.19",
     "kagent-langgraph==0.7.19",
+    # kagent-langgraph 0.7.19 imports a2a.server.apps which lives in
+    # a2a-sdk <1.0. The 1.x release refactored away that import path.
+    "a2a-sdk>=0.3.0,<1.0.0",
     "openai>=1.0.0",
     "httpx>=0.27.0",
     "uvicorn>=0.32.0",


### PR DESCRIPTION
## Fix 1: `kubeflow-tensorboards` chart's `kube-rbac-proxy` sidecar image

The chart referenced `gcr.io/kubebuilder/kube-rbac-proxy:v0.8.0`, which has been pruned from `gcr.io` by the upstream maintainers. The image no longer resolves and the `tensorboard-controller` pod fails with `ImagePullBackOff` — confirmed via `kubectl describe pod` on a fresh apply.

- Bumped the sidecar image to `quay.io/brancz/kube-rbac-proxy:v0.19.1` (maintainer-mirrored, current).
- Chart version `1.0.0` → `1.0.1`.
- Updated `eks-cluster/terraform/aws-eks-cluster-and-nodegroup/kubeflow/main.tf` helm_release version reference to match.

**Validation:** `terraform apply` reconciles the helm release cleanly. `tensorboard-controller-deployment` pod runs `3/3` (manager + auth-proxy + the new rbac-proxy sidecar).

## Fix 2: `eks-ops-agent` Docker build broken by `a2a-sdk 1.x` refactor

`kagent-langgraph 0.7.19` (the pinned version in `eks-ops-agent/pyproject.toml`) imports `A2AStarletteApplication` from `a2a.server.apps`. The `a2a-sdk 1.x` release refactored that module away — `a2a.server.apps` is no longer present in 1.0+. Without an explicit upper bound, `uv` resolves `a2a-sdk` to the latest (1.1.0) and the Docker build fails on the import-verification step.

- Added an explicit `a2a-sdk>=0.3.0,<1.0.0` constraint to `pyproject.toml` with an inline comment explaining the constraint.

**Validation:** image builds successfully, the eks-ops-agent pod starts cleanly in both Module 1 (`ENABLE_MCP_TOOLS=false`, Bedrock Q&A only) and Module 2 (`ENABLE_MCP_TOOLS=true`, with 20 EKS MCP tools loaded). End-to-end JSONRPC `message/send` to the agent returns a Bedrock-backed response.
