### PR TITLE
Adds scenario based examples of AWS DevOps Agent as an autonomous SRE teammate for EKS

### DIFF
--- a/examples/agentic/aws-devops-agent-workshop/.gitignore
+++ b/examples/agentic/aws-devops-agent-workshop/.gitignore
@@ -1,0 +1,8 @@
+scripts/env.sh
+terraform/.terraform/
+terraform/.terraform.lock.hcl
+terraform/*.tfvars
+!terraform/*.tfvars.example
+terraform/*.tfstate
+terraform/*.tfstate.backup
+terraform/*.tfplan

--- a/examples/agentic/aws-devops-agent-workshop/README.md
+++ b/examples/agentic/aws-devops-agent-workshop/README.md
@@ -1,0 +1,72 @@
+# AWS DevOps Agent — EKS SRE Workshop
+
+Demos AWS DevOps Agent (the managed service) as an autonomous SRE teammate for EKS, with two tracks:
+
+- **Track A — Foundation:** 6 general SRE scenarios (health check, OOMKill, bad deploy, cascading failure, proactive prevention, agent skills).
+- **Track B — ML Inference Ops:** 2 ML-specific scenarios (Ray Serve scheduling failure, Ray worker OOMKill) inspired by `examples/inference/rayserve/`.
+
+Both tracks validated live against AWS DevOps Agent on a K8s 1.35 cluster. The agent produced Tier-1 reasoning on every scenario — no custom Skills needed.
+
+## Layout
+
+```
+aws-devops-agent-workshop/
+├── docs/
+│   └── scenario-playbook.md            # full narrative + scenario tables + status & maturity
+├── terraform/                          # codified EKS access entry + AmazonAIOpsAssistantPolicy
+│   ├── main.tf
+│   ├── variables.tf
+│   ├── outputs.tf
+│   ├── versions.tf
+│   └── terraform.tfvars.example
+├── scripts/
+│   ├── _common.sh                      # shared helpers (auto-detects cluster from kubeconfig)
+│   ├── env.sh.example                  # template for runtime env (gitignored env.sh)
+│   ├── pre-demo-check.sh
+│   ├── cleanup.sh
+│   ├── scenario-1-healthcheck.sh
+│   ├── scenario-2-oomkill-{setup,teardown}.sh
+│   ├── scenario-3-bad-deployment-{setup,teardown}.sh
+│   ├── scenario-4-cascading-failure-{setup,teardown}.sh
+│   ├── scenario-4b-insights-followup.sh
+│   ├── scenario-5-prevention.sh
+│   ├── scenario-6-skills.md            # console walkthrough — no shell script
+│   ├── scenario-7-rayserve-toleration-{setup,teardown}.sh
+│   └── scenario-8-rayserve-oomkill-{setup,teardown}.sh
+└── manifests/
+    └── demo-workload.yaml
+```
+
+## Quick start
+
+1. **Wire AWS DevOps Agent to your EKS cluster** (codifies the workshop's Module 1 manual steps):
+   ```bash
+   cd examples/agentic/aws-devops-agent-workshop/terraform
+   cp terraform.tfvars.example terraform.tfvars
+   # Edit terraform.tfvars with your cluster name + Agent Space IAM role ARN
+   terraform init
+   terraform apply
+   ```
+
+2. **Deploy the EKS Node Diagnostics MCP server** (one-time, lives in your account):
+   See [aws-samples/sample-eks-node-diagnostics-mcp](https://github.com/aws-samples/sample-eks-node-diagnostics-mcp). Register the resulting MCP gateway URL as a Capability Provider in your Agent Space.
+
+3. **Install the CloudWatch Observability EKS add-on** (required for Scenarios 2, 4, and 8).
+
+4. **Run the demo:**
+   ```bash
+   cd examples/agentic/aws-devops-agent-workshop
+   bash scripts/pre-demo-check.sh
+   # Track A:
+   bash scripts/scenario-1-healthcheck.sh
+   bash scripts/scenario-2-oomkill-setup.sh    # ...etc
+   # Track B (requires Karpenter + KubeRay + Container Insights):
+   bash scripts/scenario-7-rayserve-toleration-setup.sh
+   bash scripts/scenario-8-rayserve-oomkill-setup.sh
+   ```
+
+## See also
+
+- [docs/scenario-playbook.md](docs/scenario-playbook.md) — full scenario narrative with key messages, expected agent behavior, and demo flow timings (Track A ~50 min, Track B ~25 min, both ~75 min)
+- `examples/inference/rayserve/meta-llama3-8b-vllm/` — the real Ray Serve / vLLM example that Track B's scenarios mock
+- `charts/machine-learning/serving/rayserve/` — the Helm chart Track B scenarios point the agent at for fixes

--- a/examples/agentic/aws-devops-agent-workshop/README.md
+++ b/examples/agentic/aws-devops-agent-workshop/README.md
@@ -2,71 +2,86 @@
 
 Demos AWS DevOps Agent (the managed service) as an autonomous SRE teammate for EKS, with two tracks:
 
-- **Track A — Foundation:** 6 general SRE scenarios (health check, OOMKill, bad deploy, cascading failure, proactive prevention, agent skills).
+- **Track A — General SRE:** 6 scenarios (health check, OOMKill, bad deploy, cascading failure, proactive prevention, agent skills).
 - **Track B — ML Inference Ops:** 2 ML-specific scenarios (Ray Serve scheduling failure, Ray worker OOMKill) inspired by `examples/inference/rayserve/`.
 
-Both tracks validated live against AWS DevOps Agent on a K8s 1.35 cluster. The agent produced Tier-1 reasoning on every scenario — no custom Skills needed.
+Each scenario provides expected agent behavior and narration cues so you can drive the demo confidently. Track A focuses on cluster-level investigation; Track B focuses on Helm-values-targeted recommendations on ML workloads.
 
-## Layout
+## Architecture
 
 ```
-aws-devops-agent-workshop/
-├── docs/
-│   └── scenario-playbook.md            # full narrative + scenario tables + status & maturity
-├── terraform/                          # codified EKS access entry + AmazonAIOpsAssistantPolicy
-│   ├── main.tf
-│   ├── variables.tf
-│   ├── outputs.tf
-│   ├── versions.tf
-│   └── terraform.tfvars.example
-├── scripts/
-│   ├── _common.sh                      # shared helpers (auto-detects cluster from kubeconfig)
-│   ├── env.sh.example                  # template for runtime env (gitignored env.sh)
-│   ├── pre-demo-check.sh
-│   ├── cleanup.sh
-│   ├── scenario-1-healthcheck.sh
-│   ├── scenario-2-oomkill-{setup,teardown}.sh
-│   ├── scenario-3-bad-deployment-{setup,teardown}.sh
-│   ├── scenario-4-cascading-failure-{setup,teardown}.sh
-│   ├── scenario-4b-insights-followup.sh
-│   ├── scenario-5-prevention.sh
-│   ├── scenario-6-skills.md            # console walkthrough — no shell script
-│   ├── scenario-7-rayserve-toleration-{setup,teardown}.sh
-│   └── scenario-8-rayserve-oomkill-{setup,teardown}.sh
-└── manifests/
-    └── demo-workload.yaml
+                        ┌─────────────────────────────────────────┐
+                        │       AWS DevOps Agent (managed)        │
+                        │  Agent Space ▸ Investigations ▸ Skills  │
+                        └──┬──────────────┬──────────────────┬────┘
+                           │              │                  │
+            MCP / HTTPS + OAuth2          │ EKS API           │ AWS SDK
+                           │              │ (read-only via    │ (GetMetricData,
+                           ▼              │  AmazonAIOps-     │  StartQuery,
+                  ┌──────────────────┐    │  AssistantPolicy) │  …)
+                  │  MCP Gateway     │    │                   │
+                  │  (AgentCore)     │    │                   │
+                  └────────┬─────────┘    │                   │
+                           │              │                   ▼
+                           ▼              │           ┌─────────────────────┐
+                  ┌──────────────────┐    │           │  Amazon CloudWatch  │
+                  │  Lambda (MCP     │    │           │  • Metrics          │
+                  │  server, 20+     │    │           │    (Container       │
+                  │  diagnostic      │    │           │     Insights:       │
+                  │  tools)          │    │           │     pod_memory_*,   │
+                  └────────┬─────────┘    │           │     node_cpu_*,     │
+                           │              │           │     CFS throttling) │
+                       SSM Automation     │           │  • Logs             │
+                           │              │           │    (Logs Insights   │
+                           ▼              ▼           │     queries)        │
+                  ┌──────────────────┐  ┌──────────────────────────────────┐│
+                  │   EKS worker     │  │       Amazon EKS cluster         ││
+                  │   nodes          │  │                                  ││
+                  │   (kubelet,      │  │  ┌────────────┐  ┌────────────┐  ││
+                  │    iptables,     │  │  │  demo-app  │  │ml-inference│  ││
+                  │    dmesg,        │  │  │ (Track A)  │  │ (Track B)  │  ││
+                  │    CNI, etc.)    │◀─┤  └────────────┘  └────────────┘  ││
+                  └──────────────────┘  │                                  ││
+                                        │   Karpenter NodePools            ││
+                                        │   CloudWatch Observability       ││
+                                        │   add-on (publishes              ├┘
+                                        │   Container Insights metrics)    │
+                                        └─────────────────┬────────────────┘
+                                                          │
+                                                          │ publishes
+                                                          │ metrics + logs
+                                                          ▼
+                                              (back up to CloudWatch above)
+
+           ┌──────────────────────────────────┐
+           │  Terraform module (this dir)     │
+           │  • aws_eks_access_entry          │ wires the agent's IAM role
+           │  • AmazonAIOpsAssistantPolicy    │ into the cluster
+           │    association (cluster scope)   │
+           └──────────────────────────────────┘
 ```
+
+**Three paths the agent uses to investigate:**
+
+- **MCP path** — for node-OS-level data (iptables, dmesg, kubelet, CNI configs) that the K8s API can't see. Routed via the MCP Gateway and SSM Automation into worker nodes.
+- **EKS API path** — for cluster-state queries (pods, events, deployments, scheduling). Authorized by the EKS access entry + `AmazonAIOpsAssistantPolicy` that this directory's Terraform module creates.
+- **CloudWatch path** — for time-series metrics (`pod_memory_working_set`, `node_cpu_utilization`, CFS throttling) and log queries. The CloudWatch Observability EKS add-on publishes these from the cluster; the agent reads them directly via the AWS SDK using its Agent Space role.
+
+What this workshop's Terraform module provides: the access entry + policy association that lets the agent read the cluster. Everything else (Agent Space, MCP server, CloudWatch add-on) is set up separately as described in [docs/setup.md](docs/setup.md).
 
 ## Quick start
 
-1. **Wire AWS DevOps Agent to your EKS cluster** (codifies the workshop's Module 1 manual steps):
-   ```bash
-   cd examples/agentic/aws-devops-agent-workshop/terraform
-   cp terraform.tfvars.example terraform.tfvars
-   # Edit terraform.tfvars with your cluster name + Agent Space IAM role ARN
-   terraform init
-   terraform apply
-   ```
+Full step-by-step in [docs/setup.md](docs/setup.md). High level:
 
-2. **Deploy the EKS Node Diagnostics MCP server** (one-time, lives in your account):
-   See [aws-samples/sample-eks-node-diagnostics-mcp](https://github.com/aws-samples/sample-eks-node-diagnostics-mcp). Register the resulting MCP gateway URL as a Capability Provider in your Agent Space.
-
-3. **Install the CloudWatch Observability EKS add-on** (required for Scenarios 2, 4, and 8).
-
-4. **Run the demo:**
-   ```bash
-   cd examples/agentic/aws-devops-agent-workshop
-   bash scripts/pre-demo-check.sh
-   # Track A:
-   bash scripts/scenario-1-healthcheck.sh
-   bash scripts/scenario-2-oomkill-setup.sh    # ...etc
-   # Track B (requires Karpenter + KubeRay + Container Insights):
-   bash scripts/scenario-7-rayserve-toleration-setup.sh
-   bash scripts/scenario-8-rayserve-oomkill-setup.sh
-   ```
+1. Provision an EKS cluster and install the CloudWatch Observability add-on.
+2. Deploy the [EKS Node Diagnostics MCP server](https://github.com/aws-samples/sample-eks-node-diagnostics-mcp) into your account.
+3. Create an AWS DevOps Agent Space in the console and register the MCP server as a Capability Provider.
+4. Run the Terraform module in `terraform/` to wire the Agent Space's role into the cluster.
+5. Run `scripts/pre-demo-check.sh`, then walk through the scenarios in `scripts/`.
 
 ## See also
 
-- [docs/scenario-playbook.md](docs/scenario-playbook.md) — full scenario narrative with key messages, expected agent behavior, and demo flow timings (Track A ~50 min, Track B ~25 min, both ~75 min)
-- `examples/inference/rayserve/meta-llama3-8b-vllm/` — the real Ray Serve / vLLM example that Track B's scenarios mock
-- `charts/machine-learning/serving/rayserve/` — the Helm chart Track B scenarios point the agent at for fixes
+- [docs/setup.md](docs/setup.md) — step-by-step setup + run guide with narration cues and troubleshooting.
+- [docs/scenario-playbook.md](docs/scenario-playbook.md) — scenario reference with key messages, expected agent behavior, and demo flow timings (Track A ~50 min, Track B ~25 min, both ~75 min).
+- `examples/inference/rayserve/meta-llama3-8b-vllm/` — the real Ray Serve / vLLM example Track B's scenarios are inspired by.
+- `charts/machine-learning/serving/rayserve/` — the Helm chart Track B scenarios point the agent at for fixes.

--- a/examples/agentic/aws-devops-agent-workshop/docs/scenario-playbook.md
+++ b/examples/agentic/aws-devops-agent-workshop/docs/scenario-playbook.md
@@ -4,7 +4,7 @@
 
 Show how **AWS DevOps Agent** acts as an autonomous SRE teammate for EKS — replacing dashboard-hopping and manual investigation with an intelligent agent that orchestrates across your entire observability stack. Two tracks:
 
-- **Track A — Foundation:** general SRE patterns that apply to any EKS workload (web services, microservices, batch). 6 scenarios.
+- **Track A — General SRE:** patterns that apply to any EKS workload (web services, microservices, batch). 6 scenarios.
 - **Track B — ML Inference Ops:** scenarios specific to multi-node ML inference on Ray Serve / KubeRay / GPU nodepools. 2 scenarios.
 
 > **Theme: "What if your on-call engineer woke up to answers instead of alerts?"**
@@ -52,23 +52,14 @@ The agent investigates Ray Serve, KubeRay, and GPU-nodepool failures the same wa
 
 ---
 
-## Status & maturity
+## Track B
 
-| Track | Implementation | Validation | Status |
-|---|---|---|---|
-| **Track A** | Scripts ported from a prior demo branch | Validated end-to-end against AWS DevOps Agent on a 1.35 cluster (June 2026) | ✅ Production-ready demo |
-| **Track B** | Scripts written; use lightweight mocks of real Ray Serve workloads | Validated against AWS DevOps Agent on the same 1.35 cluster (June 2026). Both scenarios produced Tier-1 agent responses on the first try — no custom Skill needed. | ✅ Production-ready demo |
+Both Track B scripts use lightweight stand-ins for the real Ray Serve inference workloads in `examples/inference/rayserve/`:
 
-### Why mocks for Track B?
-
-Both Track B scripts use **lightweight mocks** of the real Ray Serve inference workloads in `examples/inference/rayserve/`:
-
-- Scenario 7 deploys a placeholder RayCluster with a deliberately wrong toleration key.
+- Scenario 7 deploys a minimal RayCluster with a deliberately wrong toleration key.
 - Scenario 8 deploys a plain Deployment labeled like a Ray worker, allocating memory beyond its Helm-configured limit.
 
-The agent's investigation path on the mock is **identical** to what it would do on a real vLLM / Llama-3 / Qwen Ray Serve deployment — the `pod_memory_working_set` vs `resources.limits.memory` story is the same; only the absolute numbers change. We validated this in the live agent test: in Scenario 8, the agent autonomously extended its mock-workload recommendation to a *production-tier* recommendation for real `meta-llama3-8b-vllm` (12Gi request / 16Gi limit, citing "LLaMA-3 8B weights ~15GB FP16"). That demonstrates the agent generalizing without us providing model size context.
-
-Mocks let scenarios run in seconds against minimal CPU pods rather than 30+ minutes of GPU spin-up + model weight downloads + custom container builds. For customer demos where time matters, this is the right tradeoff. The playbook docs always point to the real example as the production reference.
+The agent's investigation path on these stand-ins is identical to what it would do on a real vLLM / Llama-3 / Qwen Ray Serve deployment — the `pod_memory_working_set` vs `resources.limits.memory` story is the same; only the absolute numbers change. This lets the scenarios run in seconds against minimal CPU pods rather than spinning up GPU nodes, pulling multi-GB containers, and downloading model weights. The playbook always points to the real example as the production reference.
 
 ---
 
@@ -76,44 +67,44 @@ Mocks let scenarios run in seconds against minimal CPU pods rather than 30+ minu
 
 ### Track A prereqs
 
-- Live EKS cluster on a recent K8s version (1.33+ recommended; this repo's TF stack is on 1.35).
-- AWS DevOps Agent Space created in the AWS console.
-- Custom MCP server for node-level diagnostics deployed once (see [aws-samples/sample-eks-node-diagnostics-mcp](https://github.com/aws-samples/sample-eks-node-diagnostics-mcp)).
-- CloudWatch Observability EKS add-on installed (provides `pod_memory_working_set`, `node_cpu_utilization`, etc. — required for Scenarios 2, 4, and 8).
+- A live EKS cluster you can reach with `kubectl`.
+- An AWS DevOps Agent Space created in the AWS console. Note its IAM role ARN — you'll need it below.
+- The custom MCP server for node-level diagnostics deployed into your account: see [aws-samples/sample-eks-node-diagnostics-mcp](https://github.com/aws-samples/sample-eks-node-diagnostics-mcp). Register the resulting MCP gateway URL as a Capability Provider in your Agent Space.
+- The CloudWatch Observability EKS add-on installed (provides `pod_memory_working_set`, `node_cpu_utilization`, etc.). Required for Scenarios 2, 4, and 8.
 
 ### Track B additional prereqs
 
-- **Karpenter** installed (Scenario 7 demonstrates a Karpenter NodePool taint mismatch). Note: customers running managed node groups instead of Karpenter will need to adapt Scenario 7 to use a node-group taint instead.
-- **GPU node availability** — at least one Karpenter NodePool capable of provisioning a GPU instance (e.g., `g5.xlarge`). Scenario scripts fail-fast with a friendly message if GPU capacity is unavailable.
-- **KubeRay operator** installed (this repo provisions it via the Kubeflow stack when `kubeflow_platform_enabled = true`).
-- A `RayService` deployed via this repo's `charts/machine-learning/serving/rayserve/` — Scenarios 7 and 8 break workers on the existing service rather than installing a fresh one each time.
+- **Karpenter** with at least one GPU NodePool tainted `nvidia.com/gpu=true:NoSchedule`. Clusters using managed node groups instead can adapt Scenario 7 to use a node-group taint.
+- **KubeRay operator** installed in the cluster.
 
-### Codified EKS wiring (replaces workshop Module 1 manual steps)
+Each scenario script deploys its own workload on demand into the `demo-app` namespace (Track A) or `ml-inference` namespace (Track B). The corresponding teardown script removes it. No long-running RayService or vLLM workload is required ahead of time.
 
-The workshop walks the EKS access-entry + IAM policy attachment through the console manually. This repo ships a Terraform module that does it in one apply:
+### Connect AWS DevOps Agent to your EKS cluster
+
+The Agent Space is created in the AWS DevOps Agent console — that step and the IAM role for the Agent Space are out of scope for the Terraform module here. What this module does:
+
+- Creates an EKS access entry for the Agent Space's IAM role on your cluster.
+- Attaches the AWS-managed `AmazonAIOpsAssistantPolicy` (an EKS cluster access policy) with cluster scope.
+
+That gives the agent read access to the cluster's Kubernetes API. The agent's own IAM permissions (CloudWatch, EKS describe, etc.) are managed by AWS as part of the Agent Space service.
 
 ```bash
 cd examples/agentic/aws-devops-agent-workshop/terraform
-# Set your Agent Space IAM role ARN as input.
-# The module creates an EKS access entry + attaches AmazonAIOpsAssistantPolicy.
-terraform apply -var="cluster_name=<your-cluster>" \
-                -var="agent_space_role_arn=<arn from Agent Space console>"
+cp terraform.tfvars.example terraform.tfvars
+# Edit terraform.tfvars with:
+#   cluster_name         = "<your cluster>"
+#   agent_space_role_arn = "<from Agent Space → Settings → IAM role>"
+terraform init
+terraform apply
 ```
 
-That replaces:
-- Navigate to EKS console → Access tab
-- Create access entry with Agent Space IAM role ARN
-- Attach `AmazonAIOpsAssistantPolicy` with cluster scope
-
-### Demo workloads
-
-Each scenario script in `scripts/` deploys its own workload on demand, into the `demo-app` namespace (Track A) or `ml-inference` namespace (Track B). Cleanup scripts revert each one.
+This is the codified version of the workshop's manual "EKS console → Access tab → Create access entry → Attach AmazonAIOpsAssistantPolicy" steps.
 
 ---
 
-# Track A — Foundation Scenarios
+# Track A — General SRE Scenarios
 
-General SRE patterns. Run in order; later scenarios build narrative continuity for Scenario 5 (Proactive Prevention).
+Run in order; later scenarios build narrative continuity for Scenario 5 (Proactive Prevention).
 
 ### Scenario 1: Morning Health Check — "The Agent Knows Your Environment"
 
@@ -200,7 +191,7 @@ Specific to multi-node ML inference on Ray Serve / KubeRay / GPU nodepools. Buil
 | **Shows** | Cross-layer correlation: scheduling event → NodePool taint → Helm values → toleration mismatch |
 | **Prereq** | This scenario assumes Karpenter is provisioning GPU nodes via a tainted NodePool. For clusters using managed node groups, the same fault can be reproduced by replacing the Karpenter step with a node-group taint mismatch — script comments call this out. |
 | **Outcome** | Agent surfaces `0/N nodes matched the toleration key …` from scheduling events, identifies the mismatch with the actual NodePool/node-group taint, and recommends the corrected `tolerations:` block to set in the Helm values |
-| **Key Message** | The agent reads scheduling events the way an SRE would. The recommendation is "change this YAML key in the Helm values" — actionable, not just descriptive. With Claude Code wired in as a code-fix agent, this becomes "ask the agent → get diagnosis → hand to Claude Code → re-deploy" in minutes. |
+| **Key Message** | The agent reads scheduling events the way an SRE would. The recommendation is "change this YAML key in the Helm values" — actionable, not just descriptive. |
 
 **What the agent should correlate:**
 
@@ -219,7 +210,7 @@ Specific to multi-node ML inference on Ray Serve / KubeRay / GPU nodepools. Buil
 | **Shows** | Container Insights memory time-series, pod termination reason, the gap between observed peak memory and the configured limit, Helm-values-targeted recommendation |
 | **Prereq** | CloudWatch Observability EKS add-on must be active and have populated metrics for at least 5 minutes (Container Insights is required for `pod_memory_working_set`). |
 | **Outcome** | Agent retrieves `lastState.terminated.reason: OOMKilled` (exit 137), plots `pod_memory_working_set` against the configured `resources.limits.memory` from the Helm release, identifies the gap, and recommends a higher limit value to set in the Helm values file with structured rationale (observed peak + headroom). |
-| **Key Message** | The agent's OOMKill investigation on a Ray Serve worker mirrors the Track-A OOMKill investigation, but the **recommended fix is targeted at the Helm chart values** — "set `resources.limits.memory: <value>` in the rayserve chart's worker spec" — not a generic `kubectl patch`. Hand to Claude Code as a Helm-chart authoring prompt to apply. |
+| **Key Message** | The agent's OOMKill investigation on a Ray Serve worker mirrors the Track-A OOMKill investigation, but the **recommended fix is targeted at the Helm chart values** — "set `resources.limits.memory: <value>` in the rayserve chart's worker spec" — not a generic `kubectl patch`. |
 
 **What the agent should correlate:**
 
@@ -227,7 +218,7 @@ Specific to multi-node ML inference on Ray Serve / KubeRay / GPU nodepools. Buil
 - 🔄 Pod termination reason: exit code 137 / `OOMKilled`
 - 🎯 Helm release values: current `resources.limits.memory` for the affected worker
 
-**Observed behavior in live validation:** The agent extended a mock-workload recommendation to a *production-tier* recommendation for the real `meta-llama3-8b-vllm` workload without prompting — citing the model size, Ray/Python overhead, and shared-memory needs explicitly. It also flagged a bonus issue (a head-pod readiness probe using `wget` against an image that doesn't have `wget`) that wasn't part of our designed fault but is exactly the kind of cross-cutting observation customers want from an autonomous investigator.
+A capable agent will extend the mock-workload recommendation to a production-tier recommendation for the real `meta-llama3-8b-vllm` workload — citing model size, Ray/Python overhead, and shared-memory needs. Cross-cutting findings (e.g., probe misconfigurations adjacent to the OOMKill) are the kind of bonus observation an autonomous investigator surfaces.
 
 ---
 
@@ -259,13 +250,4 @@ Estimated time = setup + agent investigation + narration. Add ~5 min for cleanup
 | **EKS Native** | Kubernetes API (pods, events, logs), EKS access entries, Karpenter NodePools |
 | **Node-Level Diagnostics** | Custom MCP server via SSM Automation (20+ node-level log sources). Deployed once via [aws-samples/sample-eks-node-diagnostics-mcp](https://github.com/aws-samples/sample-eks-node-diagnostics-mcp). |
 | **ML Platform** *(Track B)* | KubeRay operator, Ray Serve Helm chart from this repo's `charts/machine-learning/serving/rayserve/` |
-| **Code Fix** *(optional)* | Hand off agent diagnoses to Claude Code as a Helm-chart authoring agent |
-| **Extensibility** | Model Context Protocol (MCP) — open standard for connecting any tool |
 
----
-
-## Out of scope (deferred)
-
-- **S3 fault scenarios** — covered briefly in some workshops; deferred here pending firmer fault-injection patterns. Add as Scenario 9 in a future iteration.
-- **Multi-cluster fleet investigation** — single cluster only.
-- **Distributed training scenarios** (NCCL hangs, EFA misconfig, training-job preemption) — adjacent to Track B but a meaningfully different audience. Could be a future Track C.

--- a/examples/agentic/aws-devops-agent-workshop/docs/scenario-playbook.md
+++ b/examples/agentic/aws-devops-agent-workshop/docs/scenario-playbook.md
@@ -1,0 +1,271 @@
+# AWS DevOps Agent — EKS SRE Scenario Playbook
+
+## Objective
+
+Show how **AWS DevOps Agent** acts as an autonomous SRE teammate for EKS — replacing dashboard-hopping and manual investigation with an intelligent agent that orchestrates across your entire observability stack. Two tracks:
+
+- **Track A — Foundation:** general SRE patterns that apply to any EKS workload (web services, microservices, batch). 6 scenarios.
+- **Track B — ML Inference Ops:** scenarios specific to multi-node ML inference on Ray Serve / KubeRay / GPU nodepools. 2 scenarios.
+
+> **Theme: "What if your on-call engineer woke up to answers instead of alerts?"**
+
+---
+
+## Target Audience
+
+- **Track A:** Operations / SRE teams managing EKS clusters at scale.
+- **Track B:** ML platform engineers running multi-node LLM inference on EKS (Ray Serve, KubeRay, GPU/EFA workloads).
+
+Either track can be run independently. Track A first is the recommended path; Track B builds on the same agent + cluster setup.
+
+---
+
+## Capabilities Covered
+
+### 🤖 Agent-Driven Architecture
+
+DevOps agents redefine the single-pane-of-glass — not as a unified dashboard, but as an intelligent agent that orchestrates across all your observability tools.
+
+### 🔍 Autonomous Investigation
+
+AI agents automatically navigate across your monitoring stack to identify issues without human intervention.
+
+### ⚡ Automatic Root Cause Analysis
+
+Agents correlate signals across logs, metrics, and traces to pinpoint problems in seconds, not hours.
+
+### 💡 Actionable Insights
+
+Agents deliver context-aware recommendations and automated remediation paths.
+
+### 🛡️ Proactive Prevention
+
+The agent analyzes incident patterns to recommend improvements before issues recur.
+
+### 📋 Codified SRE Expertise
+
+Encode your team's proven runbooks as Skills — making senior-level investigation quality available to every team member from day one.
+
+### 🤖 ML Inference Awareness *(Track B)*
+
+The agent investigates Ray Serve, KubeRay, and GPU-nodepool failures the same way it investigates regular pods — but the evidence it surfaces (GPU tolerations, Karpenter NodeClaim status, Ray head/worker logs, model resource limits) is the difference between "looks broken" and "here's the exact Helm values change you need."
+
+---
+
+## Status & maturity
+
+| Track | Implementation | Validation | Status |
+|---|---|---|---|
+| **Track A** | Scripts ported from a prior demo branch | Validated end-to-end against AWS DevOps Agent on a 1.35 cluster (June 2026) | ✅ Production-ready demo |
+| **Track B** | Scripts written; use lightweight mocks of real Ray Serve workloads | Validated against AWS DevOps Agent on the same 1.35 cluster (June 2026). Both scenarios produced Tier-1 agent responses on the first try — no custom Skill needed. | ✅ Production-ready demo |
+
+### Why mocks for Track B?
+
+Both Track B scripts use **lightweight mocks** of the real Ray Serve inference workloads in `examples/inference/rayserve/`:
+
+- Scenario 7 deploys a placeholder RayCluster with a deliberately wrong toleration key.
+- Scenario 8 deploys a plain Deployment labeled like a Ray worker, allocating memory beyond its Helm-configured limit.
+
+The agent's investigation path on the mock is **identical** to what it would do on a real vLLM / Llama-3 / Qwen Ray Serve deployment — the `pod_memory_working_set` vs `resources.limits.memory` story is the same; only the absolute numbers change. We validated this in the live agent test: in Scenario 8, the agent autonomously extended its mock-workload recommendation to a *production-tier* recommendation for real `meta-llama3-8b-vllm` (12Gi request / 16Gi limit, citing "LLaMA-3 8B weights ~15GB FP16"). That demonstrates the agent generalizing without us providing model size context.
+
+Mocks let scenarios run in seconds against minimal CPU pods rather than 30+ minutes of GPU spin-up + model weight downloads + custom container builds. For customer demos where time matters, this is the right tradeoff. The playbook docs always point to the real example as the production reference.
+
+---
+
+## Setup (one-time)
+
+### Track A prereqs
+
+- Live EKS cluster on a recent K8s version (1.33+ recommended; this repo's TF stack is on 1.35).
+- AWS DevOps Agent Space created in the AWS console.
+- Custom MCP server for node-level diagnostics deployed once (see [aws-samples/sample-eks-node-diagnostics-mcp](https://github.com/aws-samples/sample-eks-node-diagnostics-mcp)).
+- CloudWatch Observability EKS add-on installed (provides `pod_memory_working_set`, `node_cpu_utilization`, etc. — required for Scenarios 2, 4, and 8).
+
+### Track B additional prereqs
+
+- **Karpenter** installed (Scenario 7 demonstrates a Karpenter NodePool taint mismatch). Note: customers running managed node groups instead of Karpenter will need to adapt Scenario 7 to use a node-group taint instead.
+- **GPU node availability** — at least one Karpenter NodePool capable of provisioning a GPU instance (e.g., `g5.xlarge`). Scenario scripts fail-fast with a friendly message if GPU capacity is unavailable.
+- **KubeRay operator** installed (this repo provisions it via the Kubeflow stack when `kubeflow_platform_enabled = true`).
+- A `RayService` deployed via this repo's `charts/machine-learning/serving/rayserve/` — Scenarios 7 and 8 break workers on the existing service rather than installing a fresh one each time.
+
+### Codified EKS wiring (replaces workshop Module 1 manual steps)
+
+The workshop walks the EKS access-entry + IAM policy attachment through the console manually. This repo ships a Terraform module that does it in one apply:
+
+```bash
+cd examples/agentic/aws-devops-agent-workshop/terraform
+# Set your Agent Space IAM role ARN as input.
+# The module creates an EKS access entry + attaches AmazonAIOpsAssistantPolicy.
+terraform apply -var="cluster_name=<your-cluster>" \
+                -var="agent_space_role_arn=<arn from Agent Space console>"
+```
+
+That replaces:
+- Navigate to EKS console → Access tab
+- Create access entry with Agent Space IAM role ARN
+- Attach `AmazonAIOpsAssistantPolicy` with cluster scope
+
+### Demo workloads
+
+Each scenario script in `scripts/` deploys its own workload on demand, into the `demo-app` namespace (Track A) or `ml-inference` namespace (Track B). Cleanup scripts revert each one.
+
+---
+
+# Track A — Foundation Scenarios
+
+General SRE patterns. Run in order; later scenarios build narrative continuity for Scenario 5 (Proactive Prevention).
+
+### Scenario 1: Morning Health Check — "The Agent Knows Your Environment"
+
+| Aspect | Detail |
+| --- | --- |
+| **What** | Agent performs a proactive cluster health assessment |
+| **Shows** | Environment awareness, resource analysis, proactive detection |
+| **Outcome** | Agent identifies CPU over-commitment, stale workloads, and resource risks — without any incident being reported |
+| **Key Message** | The agent already knows your environment and catches things humans miss |
+
+---
+
+### Scenario 2: Resource Misconfiguration — "Telemetry Correlation"
+
+| Aspect | Detail |
+| --- | --- |
+| **What** | A workload is OOMKilled due to incorrect resource limits |
+| **Shows** | CloudWatch Container Insights integration, metric-to-event correlation, resource recommendation |
+| **Outcome** | Agent correlates memory utilization trends with OOMKill events, identifies the exact misconfiguration, and provides correct resource values |
+| **Key Message** | The agent doesn't just tell you *what* happened — it correlates telemetry to explain *why*, and gives exact values to fix it |
+
+---
+
+### Scenario 3: Failed Deployment — "When Releases Go Wrong"
+
+| Aspect | Detail |
+| --- | --- |
+| **What** | A bad deployment (broken image tag) leaves a rollout stuck |
+| **Shows** | Deployment investigation, image pull failure detection, rollback recommendation |
+| **Outcome** | Agent identifies the bad image reference, traces the rollout history, and recommends whether to rollback or fix forward with exact commands |
+| **Key Message** | With GitHub/GitLab connected, the agent correlates which commit introduced the issue. Release Management (preview) can catch these *before* they hit production |
+
+---
+
+### Scenario 4: Cascading Failure — "Intelligent Observability Orchestration"
+
+| Aspect | Detail |
+| --- | --- |
+| **What** | A resource-hungry workload starves other services on the same node, causing cascading failures across multiple services |
+| **Shows** | Multi-signal correlation across CloudWatch metrics, Kubernetes events, container logs, and node-level diagnostics |
+| **Outcome** | Agent autonomously queries 4+ data sources, correlates CPU spike → pod throttling → liveness failures → restarts, and identifies the culprit workload |
+| **Key Message** | This isn't a dashboard — it's an intelligent agent that decides which tools to query, in what order, and correlates signals that would take a human 30+ minutes to connect |
+
+**What the agent correlates:**
+
+- 📊 CloudWatch: Node CPU utilization spike
+- 📋 Kubernetes Events: Pod restarts, throttling
+- 📝 Container Logs: Timeout errors, connection refused
+- 🔧 Node Diagnostics (MCP): Resource contention, CPU over-commitment
+
+---
+
+### Scenario 5: Proactive Prevention — "Getting Smarter Over Time"
+
+| Aspect | Detail |
+| --- | --- |
+| **What** | After resolving incidents, the agent analyzes patterns and recommends improvements |
+| **Shows** | Pattern recognition, observability gap detection, structured improvement recommendations |
+| **Outcome** | Agent provides targeted recommendations across 4 areas: observability, infrastructure optimization, deployment pipelines, and application resilience |
+| **Key Message** | Shifts from reactive firefighting to proactive engineering — the agent learns from every incident |
+
+---
+
+### Scenario 6: Agent Skills — "Your Playbooks, Automated"
+
+| Aspect | Detail |
+| --- | --- |
+| **What** | Show how proven investigation procedures are encoded as Skills |
+| **Shows** | Custom Skills (user-defined runbooks), Managed Skills (auto-learned), Knowledge/Memories |
+| **Outcome** | Agent follows codified procedures automatically — no need to tell it "use this skill" |
+| **Key Message** | New team members get senior-level investigation quality from day one. The agent also auto-learns from past investigations |
+
+---
+
+# Track B — ML Inference Ops Scenarios
+
+Specific to multi-node ML inference on Ray Serve / KubeRay / GPU nodepools. Builds on the same Agent Space + cluster wiring as Track A. Prereq: a `RayService` deployed via the repo's Ray Serve Helm chart, GPU nodes available via Karpenter.
+
+### Scenario 7: Ray Serve Scheduling Failure — "GPU Toleration Mismatch in Helm Values"
+
+| Aspect | Detail |
+| --- | --- |
+| **What** | A `RayService` worker pod is stuck in `Pending` because the Helm chart values specify a GPU toleration key that doesn't match the Karpenter NodePool's taint |
+| **Shows** | Cross-layer correlation: scheduling event → NodePool taint → Helm values → toleration mismatch |
+| **Prereq** | This scenario assumes Karpenter is provisioning GPU nodes via a tainted NodePool. For clusters using managed node groups, the same fault can be reproduced by replacing the Karpenter step with a node-group taint mismatch — script comments call this out. |
+| **Outcome** | Agent surfaces `0/N nodes matched the toleration key …` from scheduling events, identifies the mismatch with the actual NodePool/node-group taint, and recommends the corrected `tolerations:` block to set in the Helm values |
+| **Key Message** | The agent reads scheduling events the way an SRE would. The recommendation is "change this YAML key in the Helm values" — actionable, not just descriptive. With Claude Code wired in as a code-fix agent, this becomes "ask the agent → get diagnosis → hand to Claude Code → re-deploy" in minutes. |
+
+**What the agent should correlate:**
+
+- 📋 Kubernetes Events: `FailedScheduling` with toleration message
+- 🏷️ Karpenter NodePool / node-group spec: actual taint key/value
+- 📦 Helm release values: the `tolerations:` array on the worker spec
+- 📍 Worker pod spec: rendered tolerations vs taint
+
+---
+
+### Scenario 8: Ray Worker OOMKill — "Inference Worker Exceeds Helm-Configured Memory Limit"
+
+| Aspect | Detail |
+| --- | --- |
+| **What** | A Ray Serve worker is repeatedly OOMKilled because its actual memory usage exceeds the `resources.limits.memory` configured in the Helm values |
+| **Shows** | Container Insights memory time-series, pod termination reason, the gap between observed peak memory and the configured limit, Helm-values-targeted recommendation |
+| **Prereq** | CloudWatch Observability EKS add-on must be active and have populated metrics for at least 5 minutes (Container Insights is required for `pod_memory_working_set`). |
+| **Outcome** | Agent retrieves `lastState.terminated.reason: OOMKilled` (exit 137), plots `pod_memory_working_set` against the configured `resources.limits.memory` from the Helm release, identifies the gap, and recommends a higher limit value to set in the Helm values file with structured rationale (observed peak + headroom). |
+| **Key Message** | The agent's OOMKill investigation on a Ray Serve worker mirrors the Track-A OOMKill investigation, but the **recommended fix is targeted at the Helm chart values** — "set `resources.limits.memory: <value>` in the rayserve chart's worker spec" — not a generic `kubectl patch`. Hand to Claude Code as a Helm-chart authoring prompt to apply. |
+
+**What the agent should correlate:**
+
+- 📊 CloudWatch Container Insights: `pod_memory_working_set` time series for the Ray worker pod
+- 🔄 Pod termination reason: exit code 137 / `OOMKilled`
+- 🎯 Helm release values: current `resources.limits.memory` for the affected worker
+
+**Observed behavior in live validation:** The agent extended a mock-workload recommendation to a *production-tier* recommendation for the real `meta-llama3-8b-vllm` workload without prompting — citing the model size, Ray/Python overhead, and shared-memory needs explicitly. It also flagged a bonus issue (a head-pod readiness probe using `wget` against an image that doesn't have `wget`) that wasn't part of our designed fault but is exactly the kind of cross-cutting observation customers want from an autonomous investigator.
+
+---
+
+## Demo Flow Summary
+
+Estimated time = setup + agent investigation + narration. Add ~5 min for cleanup if you tear down between scenarios.
+
+| Track | Scenario | Est. time | Setup script | Teardown |
+|---|---|---|---|---|
+| Setup (one-time) | Codified EKS wiring | 3 min | `terraform apply` in `terraform/` | `terraform destroy` |
+| A | 1. Morning Health Check | 5 min | `scripts/scenario-1-healthcheck.sh` (prompt only) | n/a |
+| A | 2. OOMKill | 8 min | `scripts/scenario-2-oomkill-setup.sh` | `scripts/scenario-2-oomkill-teardown.sh` |
+| A | 3. Failed Deployment | 8 min | `scripts/scenario-3-bad-deployment-setup.sh` | `scripts/scenario-3-bad-deployment-teardown.sh` |
+| A | 4. Cascading Failure | 12 min | `scripts/scenario-4-cascading-failure-setup.sh` | `scripts/scenario-4-cascading-failure-teardown.sh` |
+| A | 5. Proactive Prevention | 8 min | `scripts/scenario-5-prevention.sh` (prompt only) | n/a |
+| A | 6. Agent Skills | 6 min | `scripts/scenario-6-skills.md` (console walkthrough) | n/a |
+| B | 7. Ray Serve scheduling failure | 10 min | `scripts/scenario-7-rayserve-toleration-setup.sh` | `scripts/scenario-7-rayserve-toleration-teardown.sh` |
+| B | 8. Ray worker OOMKill | 12 min | `scripts/scenario-8-rayserve-oomkill-setup.sh` | `scripts/scenario-8-rayserve-oomkill-teardown.sh` |
+
+**Track A end-to-end:** ~50 min. **Track B end-to-end:** ~25 min (after a one-time RayService deploy). **Both tracks:** ~75 min, fits a 90-minute customer demo with Q&A.
+
+---
+
+## Integrations
+
+| Category | Integrations |
+| --- | --- |
+| **Observability** | CloudWatch Container Insights, Amazon Managed Prometheus, Grafana |
+| **EKS Native** | Kubernetes API (pods, events, logs), EKS access entries, Karpenter NodePools |
+| **Node-Level Diagnostics** | Custom MCP server via SSM Automation (20+ node-level log sources). Deployed once via [aws-samples/sample-eks-node-diagnostics-mcp](https://github.com/aws-samples/sample-eks-node-diagnostics-mcp). |
+| **ML Platform** *(Track B)* | KubeRay operator, Ray Serve Helm chart from this repo's `charts/machine-learning/serving/rayserve/` |
+| **Code Fix** *(optional)* | Hand off agent diagnoses to Claude Code as a Helm-chart authoring agent |
+| **Extensibility** | Model Context Protocol (MCP) — open standard for connecting any tool |
+
+---
+
+## Out of scope (deferred)
+
+- **S3 fault scenarios** — covered briefly in some workshops; deferred here pending firmer fault-injection patterns. Add as Scenario 9 in a future iteration.
+- **Multi-cluster fleet investigation** — single cluster only.
+- **Distributed training scenarios** (NCCL hangs, EFA misconfig, training-job preemption) — adjacent to Track B but a meaningfully different audience. Could be a future Track C.

--- a/examples/agentic/aws-devops-agent-workshop/docs/setup.md
+++ b/examples/agentic/aws-devops-agent-workshop/docs/setup.md
@@ -1,0 +1,206 @@
+# Setup & Run Guide
+
+End-to-end guide for setting up and running the AWS DevOps Agent EKS workshop. Walk through the steps in order; later sections give you narration cues, troubleshooting tips, and teardown commands.
+
+For scenario-level detail (what each one demonstrates, the key messages, what the agent should surface), see [scenario-playbook.md](scenario-playbook.md).
+
+---
+
+## Step 1 — Provision an EKS cluster
+
+If you don't already have one, follow this repo's [Quick Start (Basic)](../../../../README.md#quick-start-basic). Confirm before continuing:
+
+```bash
+kubectl get nodes
+# Expect: at least one node Ready
+```
+
+> Track B (Scenarios 7–8) additionally needs Karpenter with a GPU NodePool tainted `nvidia.com/gpu=true:NoSchedule`, plus the KubeRay operator. The repo's Terraform stack provisions both when `kubeflow_platform_enabled = true`.
+
+## Step 2 — Install the CloudWatch Observability EKS add-on
+
+Required for Scenarios 2, 4, 4b, and 8 — provides `pod_memory_working_set`, `node_cpu_utilization`, and CFS-throttling metrics.
+
+```bash
+aws eks create-addon \
+  --cluster-name <your-cluster> \
+  --region <your-region> \
+  --addon-name amazon-cloudwatch-observability
+```
+
+Wait until the add-on is `ACTIVE` and metrics have populated (5+ minutes):
+
+```bash
+aws eks describe-addon \
+  --cluster-name <your-cluster> --region <your-region> \
+  --addon-name amazon-cloudwatch-observability \
+  --query 'addon.status'
+# Expect: "ACTIVE"
+
+aws cloudwatch list-metrics --namespace ContainerInsights --region <your-region> \
+  --metric-name node_cpu_utilization \
+  --query 'Metrics[0].Dimensions'
+# Expect: dimensions including your cluster name
+```
+
+## Step 3 — Deploy the EKS Node Diagnostics MCP server
+
+This is the custom MCP server the AWS DevOps Agent uses to reach node-OS-level data (iptables, dmesg, kubelet logs, etc.) via SSM Automation. It runs in your account and is required for Scenario 4.
+
+Deploy it from [aws-samples/sample-eks-node-diagnostics-mcp](https://github.com/aws-samples/sample-eks-node-diagnostics-mcp) following its README. When the CDK deploy completes, save the four values it prints:
+
+- **MCP gateway URL**
+- **OAuth Client ID**
+- **OAuth Client Secret**
+- **Token URL**
+
+You'll paste them into the AWS DevOps Agent console in Step 5.
+
+## Step 4 — Create an AWS DevOps Agent Space
+
+In the AWS console:
+
+1. Open **DevOps Agent** → **Create Agent Space**.
+2. Name it (e.g., `eks-workshop`) and choose your region.
+3. After creation, open the Agent Space → **Settings** → **IAM role**. Copy the role ARN — you'll need it for Step 6.
+
+## Step 5 — Register the MCP server as a Capability Provider
+
+In the same Agent Space:
+
+1. Open **Capability Providers** → **Register**.
+2. Fill in the values from Step 3:
+   - Server name: `eks-node-diagnostics`
+   - Endpoint URL: the MCP gateway URL
+   - Auth: OAuth 2.0 → paste Client ID, Client Secret, Token URL
+3. Save. The console validates the connection and discovers the available tools.
+
+## Step 6 — Wire the Agent Space to your EKS cluster (Terraform)
+
+This codifies the workshop's manual access-entry steps. The module creates an EKS access entry for the Agent Space role and attaches `AmazonAIOpsAssistantPolicy` with cluster scope.
+
+```bash
+cd examples/agentic/aws-devops-agent-workshop/terraform
+cp terraform.tfvars.example terraform.tfvars
+
+# Edit terraform.tfvars:
+#   cluster_name         = "<your cluster>"
+#   agent_space_role_arn = "<the ARN from Step 4>"
+$EDITOR terraform.tfvars
+
+terraform init
+terraform apply
+```
+
+Verify:
+
+```bash
+aws eks list-associated-access-policies \
+  --cluster-name <your-cluster> \
+  --principal-arn <agent-space-role-arn> \
+  --query 'associatedAccessPolicies[].policyArn'
+# Expect: ["arn:aws:eks::aws:cluster-access-policy/AmazonAIOpsAssistantPolicy"]
+```
+
+## Step 7 — Pre-demo check
+
+```bash
+cd examples/agentic/aws-devops-agent-workshop
+bash scripts/pre-demo-check.sh
+```
+
+Confirms kubectl reachability, Container Insights, CoreDNS, and namespace state. If any line says `FAIL`, fix it before running the scenarios.
+
+## Step 8 — Open the windows you'll need during the demo
+
+Have these ready before pasting the first prompt:
+
+- **Browser tab 1:** AWS DevOps Agent → your Agent Space (chat window).
+- **Browser tab 2:** CloudWatch → Container Insights → Performance monitoring → EKS Pods (filter to your cluster, namespace `demo-app` for Track A and `ml-inference` for Track B).
+- **Browser tab 3:** AWS DevOps Agent → Investigations (for the audit trail / screenshots).
+- **Terminal 1:** `kubectl` context set to the target cluster.
+- **Terminal 2:** `aws logs tail /aws/bedrock-agentcore/EksNodeLogMcpStack-gateway --region <your-region> --follow` (so you can see the MCP gateway calls live while the agent investigates).
+
+---
+
+## Step 9 — Run the scenarios
+
+Recommended order matches the playbook. Time estimates include the agent's reply window.
+
+### Track A — General SRE (≈ 50 min)
+
+| Step | Command | What to do when prompt prints | Narration cue |
+|---|---|---|---|
+| 1 | `bash scripts/scenario-1-healthcheck.sh` | Paste the printed prompt into the Agent Space chat. Wait for the report. | Look at what it surfaced *without* anyone reporting an incident — that's the demo's opening hook. Point out any pre-existing findings (e.g., long-stuck pending pods) as proof of "agent already knows your environment." |
+| 2 | `bash scripts/scenario-2-oomkill-setup.sh` | Paste prompt. | The agent should cite exit code 137 and the time-to-OOMKill ("~1 second"). With Container Insights, it also plots `pod_memory_working_set` vs limit. Run teardown after. |
+| 3 | `bash scripts/scenario-2-oomkill-teardown.sh` | — | — |
+| 4 | `bash scripts/scenario-3-bad-deployment-setup.sh` | Paste prompt. | Listen for "previous revision is healthy, no production impact yet" before recommending action. That nuance is the SRE-judgment moment. |
+| 5 | `bash scripts/scenario-3-bad-deployment-teardown.sh` | — | — |
+| 6 | `bash scripts/scenario-4-cascading-failure-setup.sh` | Paste prompt. | Headline scene. The agent correlates K8s events + CloudTrail (who deployed the culprit + when) + node metrics. Often cites credit exhaustion timing for t3a nodes. |
+| 7 | `bash scripts/scenario-4b-insights-followup.sh` | Paste prompt (after the first scenario-4 response). | The agent re-investigates using time-series metrics. Watch for it to *correct itself* if its first answer was inference-based. Highlight the honesty about Container Insights data gaps. |
+| 8 | `bash scripts/scenario-4-cascading-failure-teardown.sh` | — | — |
+| 9 | `bash scripts/scenario-5-prevention.sh` | Paste prompt. | Agent reviews everything investigated today. Expect a P0–P3 sprint plan grouped by observability / infrastructure / pipelines / resilience. |
+| 10 | Open `scripts/scenario-6-skills.md` and walk through in the Agent Space console UI. | — | This step is doc-driven (no script). Demonstrates the **Skills tab** — how proven investigation procedures get encoded as custom Skills the agent applies automatically. |
+
+### Track B — ML Inference Ops (≈ 25 min)
+
+| Step | Command | What to do when prompt prints | Narration cue |
+|---|---|---|---|
+| 11 | `bash scripts/scenario-7-rayserve-toleration-setup.sh` | Paste prompt. Allow ~60s after setup for the FailedScheduling event to populate. | The fault is *layered*: surface error says "Insufficient GPU"; real cause is a toleration mismatch making Karpenter decline to provision. A good agent response digs past the surface message and recommends the exact Helm-values toleration fix. |
+| 12 | `bash scripts/scenario-7-rayserve-toleration-teardown.sh` | — | — |
+| 13 | `bash scripts/scenario-8-rayserve-oomkill-setup.sh` | Paste prompt. OOMKills appear within 6s. | A capable agent will extend the mock-workload recommendation to a *production-tier* recommendation for the real `meta-llama3-8b-vllm` workload — citing model size, Ray overhead, KV cache. That's the "ML-awareness without being told" moment. |
+| 14 | `bash scripts/scenario-8-rayserve-oomkill-teardown.sh` | — | — |
+
+### Post-flight (1 min)
+
+```bash
+bash scripts/cleanup.sh
+```
+
+Removes any lingering demo workloads. Cluster is back to a clean baseline.
+
+---
+
+## Narration patterns
+
+Three reusable phrases that work in almost every scenario response:
+
+- **"Notice it didn't just describe what happened — it explained *why*."** Use whenever the agent moves from observation → causal reasoning.
+- **"And it gave me the exact remediation, not a generic recommendation."** Use whenever the agent produces a `kubectl ...` or `helm upgrade ...` command targeted at the specific resource at fault.
+- **"It also surfaced something I didn't ask about."** Use whenever the agent volunteers a finding outside the scope of the question. This is the moment that distinguishes an autonomous agent from a tool-use loop.
+
+---
+
+## Interpreting the agent's output
+
+A few patterns worth knowing before you read the agent's responses out loud to an audience:
+
+- **The agent surfaces evidence + reasoning + remediation.** Look for all three. If a response is missing the evidence layer (e.g., a memory recommendation with no `pod_memory_working_set` reference), pull on that thread with a follow-up question.
+- **Verify specific evidence claims against the actual resource.** Like any LLM-driven tool, the agent can occasionally over-specify a detail. The direction of the finding is usually right; specific details can drift. Confirm before acting.
+- **Bonus findings are a feature.** The agent will often surface cross-cutting issues outside the scope of your question — a misconfigured probe noticed during an OOMKill investigation, a dual-autoscaler conflict noticed during a scheduling failure. Treat these as signal, validate, and follow up.
+- **Custom Skills shape behavior.** If a scenario produces a response too generic for your needs, the right next step is to encode the investigation lens you want as a Custom Skill (see Scenario 6) so the agent applies it automatically.
+
+---
+
+## Troubleshooting
+
+| Symptom | Most likely cause | Fix |
+|---|---|---|
+| Agent says "doesn't have kubectl access to this cluster" | Step 6 was never run, or wrong ARN | Re-run terraform with the correct Agent Space role ARN |
+| Agent gives a generic "raise the memory limit" answer in Scenario 2 or 8 (not specific values) | Container Insights metrics not yet flowing | Wait 5+ minutes after add-on installation; verify with `aws cloudwatch list-metrics --namespace ContainerInsights` |
+| Scenario 7 worker pod is `Running` instead of `Pending` | A worker node already has the wrong-key toleration applied (unlikely) | Check `kubectl describe pod` for the scheduling event; adjust the script's wrong toleration key to something more unique |
+| `pre-demo-check.sh` warns about `session-manager-plugin` | Not required for these scenarios | Ignore the warning |
+| Scenario 4 agent doesn't correlate the CloudTrail user who deployed batch-processor | Your IAM session's events are out of the visible CloudTrail window | Re-run scenario 4 setup with a fresh IAM session |
+
+---
+
+## Teardown
+
+When the demo is fully complete and you want to remove the wiring:
+
+```bash
+cd examples/agentic/aws-devops-agent-workshop/terraform
+terraform destroy
+```
+
+That removes the EKS access entry + policy association. The cluster itself, the Agent Space, the MCP server, and the CloudWatch Observability add-on remain (they're outside this module's scope). Delete those separately when you're done with the cluster.

--- a/examples/agentic/aws-devops-agent-workshop/docs/setup.md
+++ b/examples/agentic/aws-devops-agent-workshop/docs/setup.md
@@ -62,7 +62,22 @@ In the AWS console:
 
 1. Open **DevOps Agent** → **Create Agent Space**.
 2. Name it (e.g., `eks-workshop`) and choose your region.
-3. After creation, open the Agent Space → **Settings** → **IAM role**. Copy the role ARN — you'll need it for Step 6.
+3. Find the Agent Space's **runtime execution role** ARN — you'll need it for Step 6.
+
+> **Important:** an Agent Space has two associated IAM roles. The "Operator access" role shown under **Settings** is the *administrator* role used to set up and configure the Space — **not** the role the agent assumes when it investigates your cluster. The Terraform module in Step 6 needs the **runtime execution role**, otherwise the agent will report "kubectl access not configured" even after `terraform apply` succeeds.
+>
+> The most reliable way to find the runtime role is via CloudTrail after the agent makes its first call:
+>
+> 1. From the Agent Space chat, run any prompt that touches the cluster (e.g., "list pods in the default namespace").
+> 2. The agent will fail with an access error the first time — that's expected.
+> 3. Run:
+>    ```bash
+>    aws cloudtrail lookup-events \
+>      --lookup-attributes AttributeKey=EventName,AttributeValue=ListAccessEntries \
+>      --max-results 5
+>    ```
+>    Or look for any `eks:Describe*` / `eks:List*` event your Agent Space role attempted. The `userIdentity.arn` on those events is the runtime role.
+> 4. Use that ARN in Step 6.
 
 ## Step 5 — Register the MCP server as a Capability Provider
 

--- a/examples/agentic/aws-devops-agent-workshop/manifests/demo-workload.yaml
+++ b/examples/agentic/aws-devops-agent-workshop/manifests/demo-workload.yaml
@@ -1,0 +1,70 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: devops-agent-demo
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web-frontend
+  namespace: devops-agent-demo
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: web-frontend
+  template:
+    metadata:
+      labels:
+        app: web-frontend
+    spec:
+      containers:
+        - name: nginx
+          image: public.ecr.aws/nginx/nginx:1.27
+          ports:
+            - containerPort: 80
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-frontend
+  namespace: devops-agent-demo
+spec:
+  selector:
+    app: web-frontend
+  ports:
+    - port: 80
+      targetPort: 80
+  type: ClusterIP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dns-probe
+  namespace: devops-agent-demo
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: dns-probe
+  template:
+    metadata:
+      labels:
+        app: dns-probe
+    spec:
+      containers:
+        - name: probe
+          image: public.ecr.aws/docker/library/busybox:1.37
+          command:
+            - /bin/sh
+            - -c
+            - |
+              while true; do
+                date
+                nslookup kubernetes.default.svc.cluster.local || echo "DNS LOOKUP FAILED"
+                sleep 10
+              done

--- a/examples/agentic/aws-devops-agent-workshop/scripts/_common.sh
+++ b/examples/agentic/aws-devops-agent-workshop/scripts/_common.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Shared helpers for demo scenario scripts. Source this file at the top of each.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[1]:-${BASH_SOURCE[0]}}")" && pwd)"
+
+# Pull pinned defaults if env.sh is present, but let kubeconfig context win.
+if [[ -f "$SCRIPT_DIR/env.sh" ]]; then
+  # shellcheck disable=SC1091
+  source "$SCRIPT_DIR/env.sh" >/dev/null
+fi
+
+KCTX="$(kubectl config current-context 2>/dev/null || true)"
+if [[ -n "$KCTX" && "$KCTX" =~ ^arn:aws:eks:([^:]+):[0-9]+:cluster/(.+)$ ]]; then
+  AWS_REGION="${BASH_REMATCH[1]}"
+  EKS_CLUSTER_NAME="${BASH_REMATCH[2]}"
+elif [[ -n "$KCTX" ]]; then
+  EKS_CLUSTER_NAME="${EKS_CLUSTER_NAME:-$KCTX}"
+fi
+
+export AWS_REGION="${AWS_REGION:-us-west-2}"
+export EKS_CLUSTER_NAME="${EKS_CLUSTER_NAME:-unknown}"
+export DEMO_NAMESPACE="${DEMO_NAMESPACE:-demo-app}"
+
+banner() {
+  echo "============================================"
+  echo "$*"
+  echo "============================================"
+}
+
+prompt() {
+  echo
+  echo "============================================"
+  echo "INVESTIGATION PROMPT — paste into Agent Space:"
+  echo "============================================"
+  echo
+  echo "$*"
+  echo
+  echo "============================================"
+}
+
+ensure_namespace() {
+  kubectl create namespace "$DEMO_NAMESPACE" 2>/dev/null || true
+}

--- a/examples/agentic/aws-devops-agent-workshop/scripts/cleanup.sh
+++ b/examples/agentic/aws-devops-agent-workshop/scripts/cleanup.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Full cleanup. Safe to run repeatedly.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/_common.sh"
+
+banner "FULL CLEANUP"
+
+# Belt-and-suspenders: if CoreDNS was scaled to 0 by an older scenario, restore it.
+CURRENT=$(kubectl get deploy coredns -n kube-system -o jsonpath='{.spec.replicas}' 2>/dev/null || echo "")
+if [[ "$CURRENT" == "0" ]]; then
+  echo "CoreDNS at 0 — restoring to 2."
+  kubectl scale deployment coredns -n kube-system --replicas=2
+fi
+
+for d in leaky-service payment-service web-frontend crashing-app \
+         order-api inventory-api batch-processor; do
+  kubectl delete deployment "$d" -n "$DEMO_NAMESPACE" --ignore-not-found
+done
+
+kubectl delete namespace "$DEMO_NAMESPACE" --ignore-not-found
+rm -f /tmp/coredns-replicas.txt
+
+echo "✓ Cleanup complete."

--- a/examples/agentic/aws-devops-agent-workshop/scripts/env.sh.example
+++ b/examples/agentic/aws-devops-agent-workshop/scripts/env.sh.example
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Demo environment template. Copy to env.sh and fill in your values.
+#   cp env.sh.example env.sh
+# env.sh is gitignored.
+
+export AWS_REGION="us-west-2"
+export AWS_ACCOUNT_ID="<YOUR_ACCOUNT_ID>"
+export EKS_CLUSTER_NAME="<YOUR_CLUSTER_NAME>"
+export EKS_NODEGROUP_NAME="<YOUR_NODEGROUP_NAME>"
+export EKS_NODE_ROLE_ARN="arn:aws:iam::<YOUR_ACCOUNT_ID>:role/<YOUR_NODE_ROLE_NAME>"
+export DEMO_NAMESPACE="demo-app"
+# Scope the MCP server's ssm:SendCommand IAM permission to this cluster only.
+export ALLOWED_CLUSTER_NAMES="<YOUR_CLUSTER_NAME>"
+
+echo "AWS_REGION=$AWS_REGION"
+echo "EKS_CLUSTER_NAME=$EKS_CLUSTER_NAME"
+echo "DEMO_NAMESPACE=$DEMO_NAMESPACE"

--- a/examples/agentic/aws-devops-agent-workshop/scripts/pre-demo-check.sh
+++ b/examples/agentic/aws-devops-agent-workshop/scripts/pre-demo-check.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Pre-demo sanity check: cluster reachable, container insights present, plugin installed.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/_common.sh"
+
+banner "PRE-DEMO CHECK"
+echo "Context: $(kubectl config current-context 2>/dev/null || echo '<none>')"
+echo "Cluster: $EKS_CLUSTER_NAME    Region: $AWS_REGION    Namespace: $DEMO_NAMESPACE"
+echo
+
+ok=1
+
+step() { printf "  [%s] %s\n" "$1" "$2"; }
+
+if kubectl get nodes >/dev/null 2>&1; then
+  step "OK" "kubectl can reach the cluster"
+else
+  step "FAIL" "kubectl cannot reach the cluster"
+  ok=0
+fi
+
+if kubectl get pods -n amazon-cloudwatch 2>/dev/null | grep -q Running; then
+  step "OK" "Container Insights running in amazon-cloudwatch namespace"
+else
+  step "WARN" "Container Insights not detected (OOMKill scene will lack metrics)"
+fi
+
+if command -v session-manager-plugin >/dev/null 2>&1; then
+  step "OK" "session-manager-plugin installed"
+else
+  step "WARN" "session-manager-plugin not installed (not required for new DNS scenario)"
+fi
+
+if kubectl get deploy -n kube-system coredns >/dev/null 2>&1; then
+  replicas=$(kubectl get deploy coredns -n kube-system -o jsonpath='{.spec.replicas}')
+  step "OK" "CoreDNS deployment found (replicas=$replicas)"
+else
+  step "FAIL" "CoreDNS deployment not found in kube-system"
+  ok=0
+fi
+
+if kubectl get ns "$DEMO_NAMESPACE" >/dev/null 2>&1; then
+  step "INFO" "Namespace $DEMO_NAMESPACE already exists — run cleanup.sh if from a prior run"
+else
+  step "OK" "Namespace $DEMO_NAMESPACE not yet created"
+fi
+
+echo
+if [[ $ok -eq 1 ]]; then
+  echo "Ready to demo."
+else
+  echo "FAIL — fix the issues above before starting."
+  exit 1
+fi

--- a/examples/agentic/aws-devops-agent-workshop/scripts/scenario-1-healthcheck.sh
+++ b/examples/agentic/aws-devops-agent-workshop/scripts/scenario-1-healthcheck.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Scenario 1: Morning Health Check. No setup needed — prints prompts only.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/_common.sh"
+
+banner "SCENARIO 1: Morning Health Check ($EKS_CLUSTER_NAME / $AWS_REGION)"
+
+prompt "Run a health check on my EKS cluster $EKS_CLUSTER_NAME in $AWS_REGION. Check all nodes for pressure conditions, identify any pods in error states, and flag any resource concerns."
+
+echo
+echo "FOLLOW-UP PROMPT (after results):"
+echo "  Which namespaces are consuming the most resources? Are any workloads at"
+echo "  risk of being OOMKilled based on current utilization vs. limits?"

--- a/examples/agentic/aws-devops-agent-workshop/scripts/scenario-2-oomkill-setup.sh
+++ b/examples/agentic/aws-devops-agent-workshop/scripts/scenario-2-oomkill-setup.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Scenario 2: OOMKill — 256Mi workload constrained to 128Mi limit.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/_common.sh"
+
+banner "SCENARIO 2: OOMKill (memory misconfiguration)"
+
+echo "[1/3] Ensuring namespace $DEMO_NAMESPACE"
+ensure_namespace
+
+echo "[2/3] Deploying leaky-service (256Mi workload, 128Mi limit)"
+kubectl apply -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: leaky-service
+  namespace: $DEMO_NAMESPACE
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: leaky-service
+  template:
+    metadata:
+      labels:
+        app: leaky-service
+    spec:
+      containers:
+        - name: leaker
+          image: public.ecr.aws/docker/library/python:3.12-slim
+          command: ["python", "-c"]
+          args:
+            - |
+              # Allocate ~256MB of RSS to trigger OOMKill against the 128Mi limit.
+              data = bytearray(256 * 1024 * 1024)
+              import time
+              while True:
+                  time.sleep(60)
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+            limits:
+              memory: "128Mi"
+              cpu: "200m"
+EOF
+
+echo "[3/3] Waiting up to 60s for OOMKills to appear..."
+for _ in $(seq 1 12); do
+  if kubectl get pods -n "$DEMO_NAMESPACE" -l app=leaky-service \
+       -o jsonpath='{.items[*].status.containerStatuses[*].lastState.terminated.reason}' \
+       2>/dev/null | grep -q OOMKilled; then
+    break
+  fi
+  sleep 5
+done
+
+echo
+kubectl get pods -n "$DEMO_NAMESPACE" -l app=leaky-service
+
+prompt "Pods in deployment leaky-service in namespace $DEMO_NAMESPACE (cluster $EKS_CLUSTER_NAME) are being OOMKilled repeatedly. Analyze the memory utilization from CloudWatch Container Insights, identify why the resource limits are insufficient, and recommend the correct resource configuration."

--- a/examples/agentic/aws-devops-agent-workshop/scripts/scenario-2-oomkill-teardown.sh
+++ b/examples/agentic/aws-devops-agent-workshop/scripts/scenario-2-oomkill-teardown.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/_common.sh"
+
+banner "TEARDOWN: leaky-service"
+kubectl delete deployment leaky-service -n "$DEMO_NAMESPACE" --ignore-not-found
+echo "Done."

--- a/examples/agentic/aws-devops-agent-workshop/scripts/scenario-3-bad-deployment-setup.sh
+++ b/examples/agentic/aws-devops-agent-workshop/scripts/scenario-3-bad-deployment-setup.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Scenario 3: Failed deployment rollout (ImagePullBackOff on a bad tag).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/_common.sh"
+
+banner "SCENARIO 3: Failed deployment rollout"
+
+echo "[1/3] Deploying healthy payment-service"
+ensure_namespace
+kubectl apply -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: payment-service
+  namespace: $DEMO_NAMESPACE
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: payment-service
+  template:
+    metadata:
+      labels:
+        app: payment-service
+    spec:
+      containers:
+        - name: app
+          image: public.ecr.aws/nginx/nginx:1.25
+          ports:
+            - containerPort: 80
+          readinessProbe:
+            httpGet: { path: /, port: 80 }
+            initialDelaySeconds: 5
+            periodSeconds: 5
+EOF
+
+echo "[2/3] Waiting for first rollout to be Available"
+kubectl wait --for=condition=Available deployment/payment-service -n "$DEMO_NAMESPACE" --timeout=120s
+
+echo "[3/3] Pushing bad image tag nginx:99.99.99-nonexistent"
+kubectl set image deployment/payment-service app=public.ecr.aws/nginx/nginx:99.99.99-nonexistent -n "$DEMO_NAMESPACE"
+
+echo "Waiting 20s for ImagePullBackOff..."
+sleep 20
+
+echo
+kubectl get pods -n "$DEMO_NAMESPACE" -l app=payment-service
+echo
+kubectl rollout status deployment/payment-service -n "$DEMO_NAMESPACE" --timeout=5s 2>&1 || true
+
+prompt "Deployment payment-service in namespace $DEMO_NAMESPACE (cluster $EKS_CLUSTER_NAME) is stuck during a rollout. New pods are not starting successfully. Investigate what went wrong and recommend whether to rollback or fix forward."

--- a/examples/agentic/aws-devops-agent-workshop/scripts/scenario-3-bad-deployment-teardown.sh
+++ b/examples/agentic/aws-devops-agent-workshop/scripts/scenario-3-bad-deployment-teardown.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/_common.sh"
+
+banner "TEARDOWN: payment-service"
+kubectl rollout undo deployment/payment-service -n "$DEMO_NAMESPACE" 2>/dev/null || true
+sleep 3
+kubectl delete deployment payment-service -n "$DEMO_NAMESPACE" --ignore-not-found
+echo "Done."

--- a/examples/agentic/aws-devops-agent-workshop/scripts/scenario-4-cascading-failure-setup.sh
+++ b/examples/agentic/aws-devops-agent-workshop/scripts/scenario-4-cascading-failure-setup.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Scenario 4: Cascading failure — multi-signal correlation demo.
+# A CPU-hog batch-processor starves order-api + inventory-api on the same node,
+# producing symptoms across CloudWatch metrics, K8s events, and node diagnostics.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/_common.sh"
+
+banner "SCENARIO 4: Cascading failure (multi-signal)"
+echo "Story: A runaway batch-processor consumes node CPU, starving order-api and"
+echo "inventory-api. Symptoms span metrics, logs, events, and node diagnostics —"
+echo "the agent must correlate across all of them."
+echo
+
+echo "[1/4] Deploying victim services (order-api, inventory-api)"
+ensure_namespace
+kubectl apply -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: order-api
+  namespace: $DEMO_NAMESPACE
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: order-api
+  template:
+    metadata:
+      labels:
+        app: order-api
+    spec:
+      containers:
+        - name: app
+          image: public.ecr.aws/nginx/nginx:1.27
+          ports:
+            - containerPort: 80
+          resources:
+            requests: { cpu: "100m", memory: "64Mi" }
+            limits:   { cpu: "200m", memory: "128Mi" }
+          livenessProbe:
+            httpGet: { path: /, port: 80 }
+            initialDelaySeconds: 5
+            periodSeconds: 3
+            failureThreshold: 3
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inventory-api
+  namespace: $DEMO_NAMESPACE
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: inventory-api
+  template:
+    metadata:
+      labels:
+        app: inventory-api
+    spec:
+      containers:
+        - name: app
+          image: public.ecr.aws/nginx/nginx:1.27
+          ports:
+            - containerPort: 80
+          resources:
+            requests: { cpu: "100m", memory: "64Mi" }
+            limits:   { cpu: "200m", memory: "128Mi" }
+          livenessProbe:
+            httpGet: { path: /, port: 80 }
+            initialDelaySeconds: 5
+            periodSeconds: 3
+            failureThreshold: 3
+EOF
+
+echo "[2/4] Waiting for victim services to be Ready"
+kubectl wait --for=condition=Ready pod -l app=order-api -n "$DEMO_NAMESPACE" --timeout=90s 2>/dev/null || true
+kubectl wait --for=condition=Ready pod -l app=inventory-api -n "$DEMO_NAMESPACE" --timeout=90s 2>/dev/null || true
+
+echo "[3/4] Deploying CPU-hungry batch-processor (the culprit)"
+kubectl apply -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: batch-processor
+  namespace: $DEMO_NAMESPACE
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: batch-processor
+  template:
+    metadata:
+      labels:
+        app: batch-processor
+    spec:
+      containers:
+        - name: cpu-stress
+          image: public.ecr.aws/docker/library/python:3.12-slim
+          command: ["python", "-c"]
+          args:
+            - |
+              # Burn CPU on 2 threads to starve co-scheduled pods.
+              import threading
+              def burn():
+                  while True:
+                      pass
+              for _ in range(2):
+                  threading.Thread(target=burn, daemon=True).start()
+              import time; time.sleep(600)
+          resources:
+            requests: { cpu: "500m" }
+            limits:   { cpu: "1500m" }
+EOF
+
+echo "[4/4] Waiting 60s for cascade symptoms to develop..."
+sleep 60
+
+echo
+echo "Current state:"
+kubectl get pods -n "$DEMO_NAMESPACE" -o wide
+echo
+echo "Node CPU (metrics-server):"
+kubectl top nodes 2>/dev/null || echo "(metrics-server not installed — agent will use CloudWatch instead)"
+
+prompt "My order-api and inventory-api services in namespace $DEMO_NAMESPACE (cluster $EKS_CLUSTER_NAME) are experiencing high latency and intermittent failures. Multiple pods show restarts. I'm seeing degraded response times across multiple services simultaneously. Investigate across all available telemetry sources — CloudWatch metrics, container logs, pod events, and node diagnostics. Correlate the signals to identify the root cause and provide a remediation plan."
+
+echo
+echo "Agent should correlate:"
+echo "  • CloudWatch CPU metrics (node-level spike)"
+echo "  • Pod events (throttling, liveness failures, restarts)"
+echo "  • MCP node diagnostics (cluster_health, quick_triage)"
+echo "  • Container logs / event timeline"
+echo "  → Root cause: batch-processor starving co-scheduled pods"
+echo "  → Remediation: resource limits, PriorityClass, node affinity / taints"

--- a/examples/agentic/aws-devops-agent-workshop/scripts/scenario-4-cascading-failure-teardown.sh
+++ b/examples/agentic/aws-devops-agent-workshop/scripts/scenario-4-cascading-failure-teardown.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/_common.sh"
+
+banner "TEARDOWN: cascading failure"
+for d in batch-processor order-api inventory-api; do
+  kubectl delete deployment "$d" -n "$DEMO_NAMESPACE" --ignore-not-found
+done
+echo "✓ Done. Node CPU should recover within 30s."

--- a/examples/agentic/aws-devops-agent-workshop/scripts/scenario-4b-insights-followup.sh
+++ b/examples/agentic/aws-devops-agent-workshop/scripts/scenario-4b-insights-followup.sh
@@ -9,7 +9,7 @@ source "$SCRIPT_DIR/_common.sh"
 banner "SCENARIO 4B: Container Insights follow-up"
 echo "Prereqs:"
 echo "  • scenario-4-cascading-failure-setup.sh has been run (batch-processor live)"
-echo "  • CloudWatch Observability EKS add-on installed (it is — verified 2026-06-22)"
+echo "  • CloudWatch Observability EKS add-on installed and ACTIVE"
 echo
 
 if ! kubectl get deploy batch-processor -n "$DEMO_NAMESPACE" >/dev/null 2>&1; then

--- a/examples/agentic/aws-devops-agent-workshop/scripts/scenario-4b-insights-followup.sh
+++ b/examples/agentic/aws-devops-agent-workshop/scripts/scenario-4b-insights-followup.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Scenario 4B: Container Insights follow-up. Run AFTER scenario-4 setup is live
+# AND after the agent's first investigation. Forces it to use CW metrics
+# (cfs_throttled_seconds, node_cpu_utilization) instead of inferring from K8s state.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/_common.sh"
+
+banner "SCENARIO 4B: Container Insights follow-up"
+echo "Prereqs:"
+echo "  • scenario-4-cascading-failure-setup.sh has been run (batch-processor live)"
+echo "  • CloudWatch Observability EKS add-on installed (it is — verified 2026-06-22)"
+echo
+
+if ! kubectl get deploy batch-processor -n "$DEMO_NAMESPACE" >/dev/null 2>&1; then
+  echo "⚠️  batch-processor not found in $DEMO_NAMESPACE — run scenario-4-cascading-failure-setup.sh first."
+  exit 1
+fi
+
+echo "batch-processor is live. Sample of metrics the agent should query:"
+echo
+aws cloudwatch list-metrics --namespace ContainerInsights --region "$AWS_REGION" \
+  --metric-name node_cpu_utilization \
+  --dimensions Name=ClusterName,Value="$EKS_CLUSTER_NAME" \
+  --query 'Metrics[0:3].Dimensions[?Name==`NodeName`].Value' --output text 2>/dev/null \
+  | head -5
+echo
+
+prompt "Now that CloudWatch Container Insights is enabled on cluster $EKS_CLUSTER_NAME, re-investigate the order-api / inventory-api degradation using the time-series metrics — not just current Kubernetes state. Specifically:
+
+1. Quote container_cpu_cfs_throttled_seconds for order-api and inventory-api pods over the last 15 minutes — what percentage of their CPU time is being stolen?
+2. Plot node_cpu_utilization for each of the 8 nodes. Identify which nodes are hot vs cold and why.
+3. Give me the exact UTC timestamp when node CPU on the affected nodes crossed 50% — correlate it with the CloudTrail event for the batch-processor apply.
+4. For pod_memory_working_set on the order-api pods, is memory pressure also contributing or is this purely CPU?
+5. Compare affected nodes to a baseline node — what's the delta in cpu_utilization, pod density, and throttling?
+
+Use the metrics to quantify the cascade, not infer it."
+
+echo
+echo "What to watch for in the agent's answer (and on the CW dashboard side-by-side):"
+echo "  ✓ Numeric CFS throttling percentages, not 'pods are being throttled'"
+echo "  ✓ Specific UTC timestamps for the cascade onset"
+echo "  ✓ Per-node comparison (hot vs cold) with deltas"
+echo "  ✓ Distinguishes CPU pressure from memory pressure"
+echo "  ✓ Cites CloudWatch namespace/dimensions in tool calls (visible in MCP gateway log)"

--- a/examples/agentic/aws-devops-agent-workshop/scripts/scenario-5-prevention.sh
+++ b/examples/agentic/aws-devops-agent-workshop/scripts/scenario-5-prevention.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Scenario 5: Proactive prevention. Run after the other scenarios so the agent
+# has investigation history to reason over. Prompt-only — no cluster changes.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/_common.sh"
+
+banner "SCENARIO 5: Proactive prevention"
+echo "Option A: open Agent Space → Improvements → 'Run Now'"
+echo "Option B: paste the prompt below."
+
+prompt "Review all the issues you've investigated in my cluster $EKS_CLUSTER_NAME today — the OOMKills, the failed deployments, the CPU starvation cascade. What patterns do you see? Recommend improvements across:
+1. Observability (what monitoring should I add?)
+2. Infrastructure (what resource configs should change?)
+3. Deployment pipelines (what gates should I add?)
+4. Application resilience (what patterns should I implement?)"

--- a/examples/agentic/aws-devops-agent-workshop/scripts/scenario-6-skills.md
+++ b/examples/agentic/aws-devops-agent-workshop/scripts/scenario-6-skills.md
@@ -1,0 +1,43 @@
+# Scenario 6: Agent Skills — "Your Playbooks, Automated"
+
+Console-only walkthrough. No shell script.
+
+## Pre-demo setup (do once, before the demo)
+
+1. Open Agent Space → Web App → **Skills** tab.
+2. Click **Create** (or **+**) under **Custom Skills**.
+3. Create this skill:
+
+**Name:** `eks-pod-failure-investigation`
+
+**Content:**
+
+```
+When investigating pod failures in an EKS cluster:
+1. First check the pod status, events, and recent restarts
+2. Pull container logs for the last 5 minutes
+3. Check node resource pressure (CPU, memory, disk) using CloudWatch or MCP tools
+4. If OOMKilled: compare resource requests/limits vs actual usage
+5. If CrashLoopBackOff: check exit codes and startup logs
+6. If Pending: check scheduling constraints, resource quotas, and node capacity
+7. Compare the affected node with a healthy node if node-level issues suspected
+8. Always provide:
+   - Root cause summary
+   - Severity rating (Critical/High/Medium/Low)
+   - Immediate fix command
+   - Long-term prevention recommendation
+```
+
+4. Toggle the skill **ON**.
+5. Verify `understanding-agent-space` managed skill is also **ON**.
+
+## During the demo
+
+1. Show the **Skills** tab (~10 sec) — point out Custom + Managed skills side by side.
+2. Say:
+   > "This encodes your team's investigation playbook. The agent follows it automatically — no need to say 'use this skill'."
+3. Reference earlier scenarios: "Notice how the OOMKill and cascading-failure investigations followed this exact structure — root cause, severity, fix command, prevention."
+
+## Key message
+
+> New team members get senior-level investigation quality from day one. Managed Skills auto-learn from past investigations; Custom Skills codify what your team already does well.

--- a/examples/agentic/aws-devops-agent-workshop/scripts/scenario-7-rayserve-toleration-setup.sh
+++ b/examples/agentic/aws-devops-agent-workshop/scripts/scenario-7-rayserve-toleration-setup.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Track B Scenario 7: Ray Serve scheduling failure due to GPU toleration mismatch.
+#
+# Story: a RayCluster's worker spec specifies the wrong toleration key for the
+# Karpenter GPU NodePool's taint. Karpenter provisions a GPU node with the
+# correct taint. The Ray worker pod stays Pending forever because its
+# toleration doesn't match the node's taint.
+#
+# Prereqs: KubeRay operator + Karpenter NodePool with GPU taint
+#   nvidia.com/gpu=true:NoSchedule (matches mlops-* clusters and most repos
+#   in this project).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/_common.sh"
+
+# Track B uses its own namespace.
+NAMESPACE="ml-inference"
+
+banner "SCENARIO 7: Ray Serve scheduling failure (GPU toleration mismatch)"
+echo "Track B — ML Inference Ops"
+echo
+echo "Story: a RayCluster worker spec carries a deliberately wrong toleration"
+echo "key. Karpenter provisions a GPU node with the correct taint, but the"
+echo "worker pod stays Pending because its toleration doesn't match."
+echo
+
+# Prereq checks ------------------------------------------------------------
+echo "[prereq] KubeRay operator"
+if ! kubectl --context "$EKS_CLUSTER_NAME" get crd rayclusters.ray.io >/dev/null 2>&1; then
+  echo "  ✗ RayCluster CRD missing. Install KubeRay first." >&2
+  echo "  This repo provisions it via kubeflow_platform_enabled = true in TF." >&2
+  exit 1
+fi
+echo "  ✓ RayCluster CRD present"
+
+echo "[prereq] Karpenter GPU NodePool with nvidia.com/gpu=true taint"
+GPU_NP=$(kubectl --context "$EKS_CLUSTER_NAME" get nodepools.karpenter.sh \
+  -o jsonpath='{range .items[?(@.spec.template.spec.taints[*].key=="nvidia.com/gpu")]}{.metadata.name}{"\n"}{end}' \
+  2>/dev/null | head -n1)
+if [[ -z "$GPU_NP" ]]; then
+  echo "  ✗ No Karpenter NodePool with nvidia.com/gpu taint found." >&2
+  echo "  Adapt this scenario to your cluster's NodePool/managed-nodegroup taint." >&2
+  exit 1
+fi
+echo "  ✓ GPU NodePool: $GPU_NP"
+
+# Deploy ------------------------------------------------------------------
+echo
+echo "[1/3] Ensuring namespace $NAMESPACE"
+kubectl --context "$EKS_CLUSTER_NAME" create namespace "$NAMESPACE" 2>/dev/null || true
+
+echo "[2/3] Deploying minimal RayCluster with WRONG toleration key"
+echo "      (toleration key: gpu=nvidia, NodePool taint: nvidia.com/gpu=true)"
+kubectl --context "$EKS_CLUSTER_NAME" apply -f - <<EOF
+apiVersion: ray.io/v1
+kind: RayCluster
+metadata:
+  name: nova-language-model
+  namespace: $NAMESPACE
+  labels:
+    ml-platform/scenario: "7"
+spec:
+  rayVersion: "2.52.1"
+  headGroupSpec:
+    rayStartParams:
+      dashboard-host: "0.0.0.0"
+    template:
+      spec:
+        containers:
+          - name: ray-head
+            image: public.ecr.aws/lts/ubuntu:22.04_stable
+            command: ["/bin/sh","-c","echo head pod placeholder; sleep 3600"]
+            resources:
+              requests: { cpu: "200m", memory: "512Mi" }
+              limits:   { cpu: "500m", memory: "1Gi" }
+  workerGroupSpecs:
+    - groupName: language-model-worker
+      replicas: 1
+      minReplicas: 1
+      maxReplicas: 1
+      rayStartParams: {}
+      template:
+        spec:
+          # WRONG toleration on purpose:
+          #   actual NodePool taint key is 'nvidia.com/gpu'
+          #   we ask for 'gpu' — so this never matches.
+          tolerations:
+            - key: "gpu"
+              operator: "Equal"
+              value: "nvidia"
+              effect: "NoSchedule"
+          containers:
+            - name: ray-worker
+              image: public.ecr.aws/lts/ubuntu:22.04_stable
+              command: ["/bin/sh","-c","echo worker pod placeholder; sleep 3600"]
+              resources:
+                requests:
+                  cpu: "500m"
+                  memory: "2Gi"
+                  nvidia.com/gpu: "1"
+                limits:
+                  cpu: "2"
+                  memory: "8Gi"
+                  nvidia.com/gpu: "1"
+EOF
+
+echo "[3/3] Waiting up to 60s for FailedScheduling event on the worker pod..."
+for _ in $(seq 1 12); do
+  if kubectl --context "$EKS_CLUSTER_NAME" -n "$NAMESPACE" get events \
+       --field-selector reason=FailedScheduling 2>/dev/null \
+       | grep -q "nova-language-model"; then
+    break
+  fi
+  sleep 5
+done
+
+echo
+echo "Pods status:"
+kubectl --context "$EKS_CLUSTER_NAME" -n "$NAMESPACE" get pods -l ray.io/cluster=nova-language-model
+
+prompt "A Ray Serve worker for our nova-language-model RayCluster in namespace $NAMESPACE (cluster $EKS_CLUSTER_NAME) is stuck in Pending. The cluster has a Karpenter NodePool ready to provision GPU instances on demand. Investigate the scheduling failure: identify the root cause, locate which Helm chart values control the toleration block, and tell me the exact change to make."
+
+echo
+echo "Agent should correlate:"
+echo "  • FailedScheduling event from Kubernetes events"
+echo "  • Karpenter NodePool taint key (nvidia.com/gpu=true)"
+echo "  • RayCluster worker tolerations (currently gpu=nvidia — wrong)"
+echo "  • Recommendation: change toleration key to nvidia.com/gpu, value true"

--- a/examples/agentic/aws-devops-agent-workshop/scripts/scenario-7-rayserve-toleration-teardown.sh
+++ b/examples/agentic/aws-devops-agent-workshop/scripts/scenario-7-rayserve-toleration-teardown.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Teardown for Scenario 7. Deletes the RayCluster + namespace.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/_common.sh"
+
+NAMESPACE="ml-inference"
+
+banner "TEARDOWN: Scenario 7 (Ray toleration mismatch)"
+kubectl --context "$EKS_CLUSTER_NAME" -n "$NAMESPACE" delete raycluster nova-language-model --ignore-not-found
+kubectl --context "$EKS_CLUSTER_NAME" delete namespace "$NAMESPACE" --ignore-not-found
+echo "✓ Done."

--- a/examples/agentic/aws-devops-agent-workshop/scripts/scenario-8-rayserve-oomkill-setup.sh
+++ b/examples/agentic/aws-devops-agent-workshop/scripts/scenario-8-rayserve-oomkill-setup.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Track B Scenario 8: Ray Serve worker OOMKill (Helm memory limit too low).
+#
+# Story: a Ray Serve worker pod (in production: a vLLM inference replica) is
+# repeatedly OOMKilled because its actual memory usage exceeds the
+# resources.limits.memory configured in the Helm values.
+#
+# This script uses a LIGHTWEIGHT MOCK: a plain Deployment labeled like a Ray
+# Serve worker, with a Python bytearray allocation that exceeds its
+# `resources.limits.memory`. The agent's investigation path (pod termination
+# reason → memory time-series → Helm values fix) is identical to what it
+# would do on a real Ray Serve vLLM deployment.
+#
+# Real-world inspiration:
+#   examples/inference/rayserve/meta-llama3-8b-vllm/rayservice.yaml
+#   chart: charts/machine-learning/serving/rayserve/
+#   knob:  resources.limits.memory on the worker spec
+#
+# Prereq: CloudWatch Observability EKS add-on with metrics populated for >5
+# minutes (Container Insights provides pod_memory_working_set the agent uses).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/_common.sh"
+
+NAMESPACE="ml-inference"
+
+banner "SCENARIO 8: Ray Serve worker OOMKill (Helm memory limit too low)"
+echo "Track B — ML Inference Ops"
+echo
+
+echo "[1/3] Ensuring namespace $NAMESPACE"
+kubectl --context "$EKS_CLUSTER_NAME" create namespace "$NAMESPACE" 2>/dev/null || true
+
+echo "[2/3] Deploying mock Ray Serve worker with UNDERSIZED memory limit"
+echo "      Allocates 256MiB against resources.limits.memory = 128Mi"
+kubectl --context "$EKS_CLUSTER_NAME" apply -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nova-vision-model
+  namespace: $NAMESPACE
+  labels:
+    ray.io/cluster: nova-vision-model
+    ray.io/node-type: worker
+    ray.io/group: vision-model-worker
+    app: ray-serve-vision-model
+    ml-platform/scenario: "8"
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: ray-serve-vision-model
+  template:
+    metadata:
+      labels:
+        ray.io/cluster: nova-vision-model
+        ray.io/node-type: worker
+        ray.io/group: vision-model-worker
+        app: ray-serve-vision-model
+    spec:
+      containers:
+        - name: ray-worker
+          image: public.ecr.aws/docker/library/python:3.12-slim
+          command: ["python","-c"]
+          args:
+            - |
+              # Mock of a vLLM inference replica loading model weights into RAM.
+              # In the real meta-llama3-8b-vllm example this would be the
+              # vLLM engine init step. Here we allocate 256MiB against a 128Mi
+              # limit so the kernel OOMKills predictably.
+              data = bytearray(256 * 1024 * 1024)
+              import time
+              while True:
+                  time.sleep(60)
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "64Mi"
+            limits:
+              cpu: "500m"
+              memory: "128Mi"   # <-- the bug we want the agent to find
+EOF
+
+echo "[3/3] Waiting up to 90s for OOMKills to appear..."
+for _ in $(seq 1 18); do
+  if kubectl --context "$EKS_CLUSTER_NAME" -n "$NAMESPACE" get pods -l app=ray-serve-vision-model \
+       -o jsonpath='{range .items[*]}{.status.containerStatuses[*].lastState.terminated.reason}{"\n"}{end}' \
+       2>/dev/null | grep -q OOMKilled; then
+    break
+  fi
+  sleep 5
+done
+
+echo
+echo "Pods:"
+kubectl --context "$EKS_CLUSTER_NAME" -n "$NAMESPACE" get pods -l app=ray-serve-vision-model -o wide
+
+prompt "Ray Serve worker pods for our nova-vision-model deployment in namespace $NAMESPACE (cluster $EKS_CLUSTER_NAME) are repeatedly OOMKilled. This is a Ray Serve inference workload deployed via the charts/machine-learning/serving/rayserve/ Helm chart, pattern similar to examples/inference/rayserve/meta-llama3-8b-vllm. Analyze the memory utilization from CloudWatch Container Insights, identify why the resource limits are insufficient, and tell me the exact Helm values change to fix it."
+
+echo
+echo "Agent should correlate:"
+echo "  • Pod termination reason: exit 137 / OOMKilled"
+echo "  • pod_memory_working_set vs the 128Mi limit"
+echo "  • Recommendation: raise resources.limits.memory in the Helm values"
+echo "    on the worker spec (e.g. 320Mi for 256MiB workload + headroom)"

--- a/examples/agentic/aws-devops-agent-workshop/scripts/scenario-8-rayserve-oomkill-teardown.sh
+++ b/examples/agentic/aws-devops-agent-workshop/scripts/scenario-8-rayserve-oomkill-teardown.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Teardown for Scenario 8. Deletes the RayCluster + namespace.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/_common.sh"
+
+NAMESPACE="ml-inference"
+
+banner "TEARDOWN: Scenario 8 (Ray worker OOMKill)"
+kubectl --context "$EKS_CLUSTER_NAME" -n "$NAMESPACE" delete raycluster nova-vision-model --ignore-not-found
+# Don't delete the namespace if Scenario 7 RayCluster is still around.
+if ! kubectl --context "$EKS_CLUSTER_NAME" -n "$NAMESPACE" get raycluster nova-language-model >/dev/null 2>&1; then
+  kubectl --context "$EKS_CLUSTER_NAME" delete namespace "$NAMESPACE" --ignore-not-found
+fi
+echo "✓ Done."

--- a/examples/agentic/aws-devops-agent-workshop/terraform/main.tf
+++ b/examples/agentic/aws-devops-agent-workshop/terraform/main.tf
@@ -1,0 +1,38 @@
+# Codifies the AWS DevOps Agent ↔ EKS wiring (workshop Module 1).
+#
+# Replaces the manual console workflow:
+#   1. EKS console → Access tab → Create access entry with the Agent Space role ARN
+#   2. Attach AmazonAIOpsAssistantPolicy with cluster scope
+#
+# Usage:
+#   terraform init
+#   terraform apply \
+#     -var="cluster_name=<your-eks-cluster>" \
+#     -var="agent_space_role_arn=<arn from Agent Space → Settings → IAM role>"
+#
+# After apply, the agent's IAM role can read the cluster (pods, events, logs)
+# via the EKS API. No write/mutate access by design — match what the workshop
+# does. To grant scoped write later, use a separate access policy
+# (e.g. AmazonEKSEditPolicy) on a different access entry.
+
+resource "aws_eks_access_entry" "agent" {
+  cluster_name  = var.cluster_name
+  principal_arn = var.agent_space_role_arn
+  type          = "STANDARD"
+
+  tags = merge(var.tags, {
+    Purpose = "aws-devops-agent-workshop"
+  })
+}
+
+resource "aws_eks_access_policy_association" "agent_aiops" {
+  cluster_name  = var.cluster_name
+  policy_arn    = "arn:aws:eks::aws:cluster-access-policy/AmazonAIOpsAssistantPolicy"
+  principal_arn = var.agent_space_role_arn
+
+  access_scope {
+    type = "cluster"
+  }
+
+  depends_on = [aws_eks_access_entry.agent]
+}

--- a/examples/agentic/aws-devops-agent-workshop/terraform/outputs.tf
+++ b/examples/agentic/aws-devops-agent-workshop/terraform/outputs.tf
@@ -1,0 +1,21 @@
+output "access_entry_arn" {
+  description = "ARN of the EKS access entry created for the Agent Space role."
+  value       = aws_eks_access_entry.agent.access_entry_arn
+}
+
+output "policy_association_id" {
+  description = "Composite ID of the AmazonAIOpsAssistantPolicy association."
+  value       = aws_eks_access_policy_association.agent_aiops.id
+}
+
+output "verification_command" {
+  description = "Run this after apply to confirm the agent can talk to the cluster."
+  value       = <<-EOT
+    aws eks list-access-entries --cluster-name ${var.cluster_name} \
+      --query 'accessEntries[?contains(@, `${var.agent_space_role_arn}`)]'
+
+    aws eks list-associated-access-policies \
+      --cluster-name ${var.cluster_name} \
+      --principal-arn ${var.agent_space_role_arn}
+  EOT
+}

--- a/examples/agentic/aws-devops-agent-workshop/terraform/terraform.tfvars.example
+++ b/examples/agentic/aws-devops-agent-workshop/terraform/terraform.tfvars.example
@@ -1,0 +1,10 @@
+# Copy to terraform.tfvars and fill in.
+# terraform.tfvars is gitignored.
+
+cluster_name         = "<your-eks-cluster>"
+agent_space_role_arn = "arn:aws:iam::<account>:role/<agent-space-role>"
+
+tags = {
+  Owner   = "<team>"
+  Project = "aws-devops-agent-workshop"
+}

--- a/examples/agentic/aws-devops-agent-workshop/terraform/variables.tf
+++ b/examples/agentic/aws-devops-agent-workshop/terraform/variables.tf
@@ -1,0 +1,26 @@
+variable "cluster_name" {
+  description = "Name of the EKS cluster to wire AWS DevOps Agent into."
+  type        = string
+}
+
+variable "agent_space_role_arn" {
+  description = <<-EOT
+    IAM role ARN from your AWS DevOps Agent Space.
+    Find it in: AWS console → DevOps Agent → Agent Space → Settings → IAM role.
+    The role typically looks like:
+      arn:aws:iam::<account>:role/AWSServiceRoleForBedrockAgentCore_<id>
+    or a custom role you've configured for the Agent Space.
+  EOT
+  type        = string
+
+  validation {
+    condition     = can(regex("^arn:aws:iam::[0-9]{12}:role/.+$", var.agent_space_role_arn))
+    error_message = "agent_space_role_arn must be a valid IAM role ARN (arn:aws:iam::<account>:role/<name>)."
+  }
+}
+
+variable "tags" {
+  description = "Optional tags applied to created EKS access entries."
+  type        = map(string)
+  default     = {}
+}

--- a/examples/agentic/aws-devops-agent-workshop/terraform/versions.tf
+++ b/examples/agentic/aws-devops-agent-workshop/terraform/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0"
+    }
+  }
+}


### PR DESCRIPTION
- Track A — General SRE Troubleshooting
- Track B — ML Inference Ops:

## What's included

- **Terraform module** (`terraform/`) that codifies the EKS access entry + `AmazonAIOpsAssistantPolicy` association for the Agent Space's IAM role.
- **Scenario scripts** (`scripts/`) for each scenario — setup + teardown + a shared helper that auto-detects the cluster from kubeconfig.
- **Setup & Run guide** (`docs/setup.md`) — Steps from EKS cluster + observability add-on + MCP server deployment through Agent Space wiring and running the scenarios.
- **Scenario playbook** (`docs/scenario-playbook.md`) — per-scenario reference with key messages, what the agent should surface, and integrations the demo exercises.




