### PR TITLE
Bump Overture release tag 

### DIFF
--- a/charts/data-service/overture-api/values.yaml
+++ b/charts/data-service/overture-api/values.yaml
@@ -6,7 +6,7 @@
 # instances per region.
 #
 # Minimum required overrides per release:
-#   overture.release  — pinned Overture release tag (e.g., "2026-06-17.0")
+#   overture.release  — pinned Overture release tag (e.g., "2026-07-22.0")
 #   overture.bbox     — bounding box [minLon, minLat, maxLon, maxLat]
 # =============================================================================
 
@@ -34,8 +34,11 @@ fsx:
 # -----------------------------------------------------------------------------
 # Overture release configuration.
 #
-# release: the Overture Maps Foundation release tag, e.g., "2026-06-17.0".
+# release: the Overture Maps Foundation release tag, e.g., "2026-07-22.0".
 #   See https://docs.overturemaps.org/release/ for current releases.
+#   NOTE: Overture applies a 60-day S3 lifecycle expiration to release data,
+#   so any pinned tag stops resolving ~60 days after publication. Bump this to
+#   a current release, or mirror the data into a bucket you control.
 # theme/type: transportation/segment is the only combination this chart serves.
 # s3SourcePrefix: base S3 path for the Overture public bucket.
 # s3Region: region hosting the bucket (Overture publishes to us-west-2).
@@ -44,7 +47,7 @@ fsx:
 #   ~50 MB and the segment count around 5,000.
 # -----------------------------------------------------------------------------
 overture:
-  release: "2026-06-17.0"
+  release: "2026-07-22.0"
   theme: "transportation"
   type: "segment"
   s3SourcePrefix: "s3://overturemaps-us-west-2/release"

--- a/examples/data-service/overture-transportation-ingolstadt/values.yaml
+++ b/examples/data-service/overture-transportation-ingolstadt/values.yaml
@@ -16,7 +16,7 @@
 namespace: kubeflow-user-example-com
 
 overture:
-  release: "2026-06-17.0"
+  release: "2026-07-22.0"
   theme: "transportation"
   type: "segment"
   s3SourcePrefix: "s3://overturemaps-us-west-2/release"


### PR DESCRIPTION


*Issue #, if available:*

Overture data-service deploy fails: pinned release tag expires via 60-day lifecycle rule.
The overture-api chart pins a hardcoded Overture release tag (overture.release) in both charts/data-service/overture-api/values.yaml and examples/data-service/overture-transportation-ingolstadt/values.yaml. Overture Maps applies a 60-day S3 lifecycle expiration to release data in the public s3://overturemaps-us-west-2/release/ bucket, so any pinned tag stops resolving ~60 days after publication.

When the tag expires, the post-install init Job (DuckDB filtering Overture parquet from S3 to FSx) fails with:


IO Error: No files found that match the pattern
"s3://overturemaps-us-west-2/release/<expired-tag>/theme=transportation/type=segment/*"

*Description of changes:*
Bumps the pinned Overture Maps release tag from 2026-06-17.0 to 2026-07-22.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
